### PR TITLE
Only load yaml signer configs

### DIFF
--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -101,7 +101,7 @@ public class Runner implements Runnable {
 
     final ArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            config.getKeyConfigPath(), new YamlSignerParser());
+            config.getKeyConfigPath(), "yaml", new YamlSignerParser());
 
     final SigningRequestHandler signingHandler =
         new SigningRequestHandler(signerProvider, createJsonDecoder());

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -37,11 +37,13 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
 
   private static final Logger LOG = LogManager.getLogger();
   private final Path configsDirectory;
+  private final String fileExtension;
   private final SignerParser signerParser;
 
   public DirectoryBackedArtifactSignerProvider(
-      final Path rootDirectory, final SignerParser signerParser) {
+      final Path rootDirectory, final String fileExtension, final SignerParser signerParser) {
     this.configsDirectory = rootDirectory;
+    this.fileExtension = fileExtension;
     this.signerParser = signerParser;
   }
 
@@ -90,7 +92,7 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
   }
 
   private Collection<ArtifactSignerWithFileName> loadAvailableSigners() {
-    return findSigners((entry) -> true);
+    return findSigners(this::matchesFileExtension);
   }
 
   private Collection<ArtifactSignerWithFileName> findSigners(
@@ -117,10 +119,16 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
   }
 
   private Filter<Path> signerIdentifierFilenameFilter(final String signerIdentifier) {
-    return entry ->
-        FilenameUtils.getBaseName(entry.getFileName().toString())
-            .toLowerCase()
-            .endsWith(signerIdentifier.toLowerCase());
+    return entry -> {
+      final String baseName = FilenameUtils.getBaseName(entry.toString());
+      return matchesFileExtension(entry)
+          && baseName.toLowerCase().endsWith(signerIdentifier.toLowerCase());
+    };
+  }
+
+  private boolean matchesFileExtension(final Path filename) {
+    final String extension = FilenameUtils.getExtension(filename.toString());
+    return extension.toLowerCase().endsWith(fileExtension.toLowerCase());
   }
 
   private boolean signerMatchesIdentifier(

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParser.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class YamlSignerParser implements SignerParser {
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper(new YAMLFactory()).registerModule(new SigningMetadataModule());
-  public static final String YAML_FILE_EXTENSION = "yaml";
 
   @Override
   public ArtifactSigner parse(final Path metadataPath) {

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import tech.pegasys.eth2signer.core.multikey.metadata.SignerParser;
@@ -43,7 +44,7 @@ class DirectoryBackedArtifactSignerProviderTest {
   @TempDir Path configsDirectory;
   @Mock private SignerParser signerParser;
 
-  private static final String FILE_EXTENSION = ".yaml";
+  private static final String FILE_EXTENSION = "yaml";
   private static final String PUBLIC_KEY =
       "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
   private static final String PRIVATE_KEY =
@@ -54,7 +55,8 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @BeforeEach
   void setup() {
-    signerProvider = new DirectoryBackedArtifactSignerProvider(configsDirectory, signerParser);
+    signerProvider =
+        new DirectoryBackedArtifactSignerProvider(configsDirectory, FILE_EXTENSION, signerParser);
   }
 
   @Test
@@ -106,6 +108,34 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  void signerReturnedWhenFileExtensionIsUpperCase() throws IOException {
+    final String metadataFilename = PUBLIC_KEY + ".YAML";
+    final File file = configsDirectory.resolve(metadataFilename).toFile();
+    file.createNewFile();
+    when(signerParser.parse(any())).thenReturn(artifactSigner);
+
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0X" + PUBLIC_KEY);
+
+    assertThat(signer).isNotEmpty();
+    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    verify(signerParser)
+        .parse(argThat((Path path) -> path != null && path.endsWith(metadataFilename)));
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  void wrongFileExtensionReturnsEmptySigner() throws IOException {
+    final String metadataFilename = PUBLIC_KEY + ".nothing";
+    final File file = configsDirectory.resolve(metadataFilename).toFile();
+    file.createNewFile();
+
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    assertThat(signer).isEmpty();
+    verifyNoMoreInteractions(signerParser);
+  }
+
+  @Test
   void failedParserReturnsEmptySigner() throws IOException {
     createFileInConfigsDirectory(PUBLIC_KEY);
     when(signerParser.parse(any())).thenThrow(SigningMetadataException.class);
@@ -116,9 +146,9 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void failedWithDirectoryErrorReturnEmptySigner() throws IOException {
-    DirectoryBackedArtifactSignerProvider signerProvider =
+    final DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            configsDirectory.resolve("idontexist"), signerParser);
+            configsDirectory.resolve("idontexist"), FILE_EXTENSION, signerParser);
     createFileInConfigsDirectory(PUBLIC_KEY);
 
     final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
@@ -193,12 +223,12 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   private Path pathEndsWith(final String endsWith) {
-    return argThat((Path path) -> path != null && path.endsWith(endsWith + FILE_EXTENSION));
+    return argThat((Path path) -> path != null && path.endsWith(endsWith + "." + FILE_EXTENSION));
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   private void createFileInConfigsDirectory(final String filename) throws IOException {
-    final File file = configsDirectory.resolve(filename + FILE_EXTENSION).toFile();
+    final File file = configsDirectory.resolve(filename + "." + FILE_EXTENSION).toFile();
     file.createNewFile();
   }
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
@@ -14,7 +14,6 @@ package tech.pegasys.eth2signer.core.multikey.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static tech.pegasys.eth2signer.core.multikey.metadata.YamlSignerParser.YAML_FILE_EXTENSION;
 
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
@@ -42,6 +41,7 @@ class YamlSignerParserTest {
   @TempDir Path configDir;
 
   private YamlSignerParser signerParser;
+  private String YAML_FILE_EXTENSION = "yaml";
 
   @BeforeEach
   public void setup() {


### PR DESCRIPTION
Changes the signer provider so it will only try to parse signer configs that match a yaml file extension. This allows us to have other files in the directory that also match the signer identifier. This useful if you have other files associated with the config that make sense to store in the config directory e.g. keystore file and the keystore password.