### PR TITLE
Sign using keys from bls keystore files

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  testImplementation 'tech.pegasys.signers.internal:bls-keystore'
 }
 
 test.enabled = false

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
@@ -13,7 +13,6 @@
 package tech.pegasys.eth2signer.dsl.utils;
 
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
-import static tech.pegasys.artemis.util.crypto.SecureRandomProvider.createSecureRandom;
 import static tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction.HMAC_SHA256;
 
 import tech.pegasys.eth2signer.crypto.KeyPair;
@@ -31,6 +30,7 @@ import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,15 +83,15 @@ public class MetadataFileHelpers {
       final String password,
       final Bytes privateKey,
       final KdfFunction kdfFunctionType) {
-    final Bytes32 iv = Bytes32.random(createSecureRandom());
+    final Bytes32 salt = Bytes32.random(new SecureRandom());
 
     final KdfParam kdfParam =
         kdfFunctionType == KdfFunction.SCRYPT
-            ? new SCryptParam(32, iv)
-            : new Pbkdf2Param(32, 262144, HMAC_SHA256, iv);
+            ? new SCryptParam(32, salt)
+            : new Pbkdf2Param(32, 262144, HMAC_SHA256, salt);
 
     final Cipher cipher =
-        new Cipher(CipherFunction.AES_128_CTR, Bytes.random(16, createSecureRandom()));
+        new Cipher(CipherFunction.AES_128_CTR, Bytes.random(16, new SecureRandom()));
     final KeyStoreData keyStoreData = KeyStore.encrypt(privateKey, password, "", kdfParam, cipher);
     try {
       KeyStoreLoader.saveToFile(keyStoreFilePath, keyStoreData);

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
@@ -13,14 +13,31 @@
 package tech.pegasys.eth2signer.dsl.utils;
 
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
+import static tech.pegasys.artemis.util.crypto.SecureRandomProvider.createSecureRandom;
+import static tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction.HMAC_SHA256;
+
+import tech.pegasys.eth2signer.crypto.KeyPair;
+import tech.pegasys.eth2signer.crypto.SecretKey;
+import tech.pegasys.signers.bls.keystore.KeyStore;
+import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
+import tech.pegasys.signers.bls.keystore.model.Cipher;
+import tech.pegasys.signers.bls.keystore.model.CipherFunction;
+import tech.pegasys.signers.bls.keystore.model.KdfFunction;
+import tech.pegasys.signers.bls.keystore.model.KdfParam;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
+import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
+import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class MetadataFileHelpers {
   final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
@@ -32,11 +49,62 @@ public class MetadataFileHelpers {
     createYamlFile(metadataFilePath, signingMetadata);
   }
 
+  public void createKeyStoreYamlFileAt(
+      final Path metadataFilePath, final String privateKey, final KdfFunction kdfFunctionType) {
+    final Bytes privateKeyBytes = Bytes.fromHexString(privateKey);
+    final KeyPair keyPair = new KeyPair(SecretKey.fromBytes(privateKeyBytes));
+
+    final String password = "password";
+    final Path passwordFile =
+        metadataFilePath.getParent().resolve(keyPair.publicKey().toString() + ".password");
+    createPasswordFile(passwordFile, password);
+
+    final Path keystoreFile =
+        metadataFilePath.getParent().resolve(keyPair.publicKey().toString() + ".json");
+    createKeyStoreFile(keystoreFile, password, privateKeyBytes, kdfFunctionType);
+
+    final Map<String, String> signingMetadata = new HashMap<>();
+    signingMetadata.put("type", "file-keystore");
+    signingMetadata.put("keystoreFile", keystoreFile.toString());
+    signingMetadata.put("keystorePasswordFile", passwordFile.toString());
+    createYamlFile(metadataFilePath, signingMetadata);
+  }
+
+  private void createPasswordFile(final Path passwordFilePath, final String password) {
+    try {
+      Files.writeString(passwordFilePath, password);
+    } catch (IOException e) {
+      fail("Unable to create password file", e);
+    }
+  }
+
+  private void createKeyStoreFile(
+      final Path keyStoreFilePath,
+      final String password,
+      final Bytes privateKey,
+      final KdfFunction kdfFunctionType) {
+    final Bytes32 iv = Bytes32.random(createSecureRandom());
+
+    final KdfParam kdfParam =
+        kdfFunctionType == KdfFunction.SCRYPT
+            ? new SCryptParam(32, iv)
+            : new Pbkdf2Param(32, 262144, HMAC_SHA256, iv);
+
+    final Cipher cipher =
+        new Cipher(CipherFunction.AES_128_CTR, Bytes.random(16, createSecureRandom()));
+    final KeyStoreData keyStoreData = KeyStore.encrypt(privateKey, password, "", kdfParam, cipher);
+    try {
+      KeyStoreLoader.saveToFile(keyStoreFilePath, keyStoreData);
+    } catch (IOException e) {
+      fail("Unable to create keystore file", e);
+    }
+  }
+
   private void createYamlFile(final Path filePath, final Map<String, String> signingMetadata) {
     try {
       YAML_OBJECT_MAPPER.writeValue(filePath.toFile(), signingMetadata);
     } catch (final IOException e) {
-      fail("Unable to create metadata file.");
+      fail("Unable to create metadata file.", e);
     }
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -21,17 +21,21 @@ import tech.pegasys.eth2signer.crypto.SecretKey;
 import tech.pegasys.eth2signer.dsl.HttpResponse;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
+import tech.pegasys.signers.bls.keystore.model.KdfFunction;
 
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class UnencryptedKeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
+public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
 
   private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
 
@@ -49,6 +53,30 @@ public class UnencryptedKeyLoadAndSignAcceptanceTest extends AcceptanceTestBase 
     final String configFilename = keyPair.publicKey().toString().substring(2);
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, privateKeyString);
+
+    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
+    builder.withKeyStoreDirectory(testDirectory);
+    startSigner(builder.build());
+
+    final String expectedSignature =
+        "0x810A4B8E878A1AD0B30F3EAE7ED35E17450E82FDDE6AAA8B500EB5A59A78E3B07684F72B014F92EBED64BD7FFEF680A00A63B84CA92A6299265A0C2339547F0432C3DEE612665C4FEE5D4D93B42D84F2E963700842F60DAE7E5B641F5BB01E64";
+
+    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
+    final Bytes domain = Bytes.ofUnsignedLong(42L);
+    final HttpResponse response =
+        signer.signData(artifactSigningEndpoint, keyPair.publicKey(), message, domain);
+    assertThat(response.getStatusCode()).isEqualTo(HttpResponseStatus.OK.code());
+    assertThat(response.getBody()).isEqualToIgnoringCase(expectedSignature);
+  }
+
+  @ParameterizedTest
+  @MethodSource("keystoreValues")
+  public void signDataWithKeyLoadedFromKeyStoreFile(
+      final String artifactSigningEndpoint, KdfFunction kdfFunction) throws Exception {
+    final String configFilename = keyPair.publicKey().toString().substring(2);
+
+    final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
+    metadataFileHelpers.createKeyStoreYamlFileAt(keyConfigFile, privateKeyString, kdfFunction);
 
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     builder.withKeyStoreDirectory(testDirectory);
@@ -83,5 +111,13 @@ public class UnencryptedKeyLoadAndSignAcceptanceTest extends AcceptanceTestBase 
 
     final HttpResponse response = signer.postRawRequest("/signer/block", "invalid Body");
     assertThat(response.getStatusCode()).isEqualTo(400);
+  }
+
+  private static Stream<Arguments> keystoreValues() {
+    return Stream.of(
+        Arguments.arguments("/signer/block", KdfFunction.SCRYPT),
+        Arguments.arguments("/signer/attestation", KdfFunction.SCRYPT),
+        Arguments.arguments("/signer/block", KdfFunction.PBKDF2),
+        Arguments.arguments("/signer/attestation", KdfFunction.PBKDF2));
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -37,11 +37,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
 
-  private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
-
-  private final String privateKeyString =
+  private static final Bytes MESSAGE = Bytes.wrap("Hello, world!".getBytes(UTF_8));
+  private static final Bytes DOMAIN = Bytes.ofUnsignedLong(42L);
+  private static final String PRIVATE_KEY =
       "000000000000000000000000000000003ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
-  private final SecretKey key = SecretKey.fromBytes(Bytes.fromHexString(privateKeyString));
+  private static final String EXPECTED_SIGNATURE =
+      "0x810A4B8E878A1AD0B30F3EAE7ED35E17450E82FDDE6AAA8B500EB5A59A78E3B07684F72B014F92EBED64BD7FFEF680A00A63B84CA92A6299265A0C2339547F0432C3DEE612665C4FEE5D4D93B42D84F2E963700842F60DAE7E5B641F5BB01E64";
+
+  private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
+  private final SecretKey key = SecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY));
   private final KeyPair keyPair = new KeyPair(key);
 
   @TempDir Path testDirectory;
@@ -52,21 +56,16 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
       throws Exception {
     final String configFilename = keyPair.publicKey().toString().substring(2);
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
-    metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, privateKeyString);
+    metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     builder.withKeyStoreDirectory(testDirectory);
     startSigner(builder.build());
 
-    final String expectedSignature =
-        "0x810A4B8E878A1AD0B30F3EAE7ED35E17450E82FDDE6AAA8B500EB5A59A78E3B07684F72B014F92EBED64BD7FFEF680A00A63B84CA92A6299265A0C2339547F0432C3DEE612665C4FEE5D4D93B42D84F2E963700842F60DAE7E5B641F5BB01E64";
-
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    final Bytes domain = Bytes.ofUnsignedLong(42L);
     final HttpResponse response =
-        signer.signData(artifactSigningEndpoint, keyPair.publicKey(), message, domain);
+        signer.signData(artifactSigningEndpoint, keyPair.publicKey(), MESSAGE, DOMAIN);
     assertThat(response.getStatusCode()).isEqualTo(HttpResponseStatus.OK.code());
-    assertThat(response.getBody()).isEqualToIgnoringCase(expectedSignature);
+    assertThat(response.getBody()).isEqualToIgnoringCase(EXPECTED_SIGNATURE);
   }
 
   @ParameterizedTest
@@ -76,7 +75,7 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     final String configFilename = keyPair.publicKey().toString().substring(2);
 
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
-    metadataFileHelpers.createKeyStoreYamlFileAt(keyConfigFile, privateKeyString, kdfFunction);
+    metadataFileHelpers.createKeyStoreYamlFileAt(keyConfigFile, PRIVATE_KEY, kdfFunction);
 
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     builder.withKeyStoreDirectory(testDirectory);
@@ -85,10 +84,8 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     final String expectedSignature =
         "0x810A4B8E878A1AD0B30F3EAE7ED35E17450E82FDDE6AAA8B500EB5A59A78E3B07684F72B014F92EBED64BD7FFEF680A00A63B84CA92A6299265A0C2339547F0432C3DEE612665C4FEE5D4D93B42D84F2E963700842F60DAE7E5B641F5BB01E64";
 
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    final Bytes domain = Bytes.ofUnsignedLong(42L);
     final HttpResponse response =
-        signer.signData(artifactSigningEndpoint, keyPair.publicKey(), message, domain);
+        signer.signData(artifactSigningEndpoint, keyPair.publicKey(), MESSAGE, DOMAIN);
     assertThat(response.getStatusCode()).isEqualTo(HttpResponseStatus.OK.code());
     assertThat(response.getBody()).isEqualToIgnoringCase(expectedSignature);
   }
@@ -98,9 +95,7 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     startSigner(builder.build());
 
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    final Bytes domain = Bytes.ofUnsignedLong(42L);
-    final HttpResponse response = signer.signData("block", PublicKey.random(), message, domain);
+    final HttpResponse response = signer.signData("block", PublicKey.random(), MESSAGE, DOMAIN);
     assertThat(response.getStatusCode()).isEqualTo(HttpResponseStatus.NOT_FOUND.code());
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -113,6 +113,7 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     assertThat(response.getStatusCode()).isEqualTo(400);
   }
 
+  @SuppressWarnings("UnusedMethod")
   private static Stream<Arguments> keystoreValues() {
     return Stream.of(
         Arguments.arguments("/signer/block", KdfFunction.SCRYPT),

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ allprojects {
     jcenter()
     mavenCentral()
     maven { url "https://hyperledger-org.bintray.com/besu-repo/" }
+    maven { url  "https://consensys.bintray.com/pegasys-repo" }
   }
 
   dependencies { errorprone("com.google.errorprone:error_prone_core") }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,6 +32,8 @@ dependencies {
   implementation 'org.hyperledger.besu.internal:metrics-core'
   implementation 'org.hyperledger.besu:plugin-api'
 
+  implementation 'tech.pegasys.signers.internal:bls-keystore'
+
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -17,6 +17,7 @@ import tech.pegasys.eth2signer.core.http.SigningRequestHandler;
 import tech.pegasys.eth2signer.core.metrics.MetricsEndpoint;
 import tech.pegasys.eth2signer.core.metrics.VertxMetricsAdapterFactory;
 import tech.pegasys.eth2signer.core.multikey.DirectoryBackedArtifactSignerProvider;
+import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.utils.JsonDecoder;
@@ -102,10 +103,11 @@ public class Runner implements Runnable {
         .failureHandler(errorHandler)
         .handler(routingContext -> routingContext.response().end("OK"));
 
+    final ArtifactSignerFactory artifactSignerFactory =
+        new ArtifactSignerFactory(config.getKeyConfigPath(), metricsSystem);
     final ArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            config.getKeyConfigPath(),
-            new YamlSignerParser(config.getKeyConfigPath(), metricsSystem));
+            config.getKeyConfigPath(), "yaml", new YamlSignerParser(artifactSignerFactory));
 
     final SigningRequestHandler signingHandler =
         new SigningRequestHandler(signerProvider, createJsonDecoder());

--- a/core/src/main/java/tech/pegasys/eth2signer/core/metrics/Eth2SignerMetricCategory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/metrics/Eth2SignerMetricCategory.java
@@ -21,7 +21,8 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
 public enum Eth2SignerMetricCategory implements MetricCategory {
-  HTTP("http");
+  HTTP("http"),
+  SIGNING("signing");
 
   private final String name;
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.multikey;
 
-import tech.pegasys.eth2signer.core.multikey.metadata.SignerParser;
+import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.multikey.metadata;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import tech.pegasys.eth2signer.core.metrics.Eth2SignerMetricCategory;
+import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.crypto.KeyPair;
+import tech.pegasys.eth2signer.crypto.SecretKey;
+import tech.pegasys.signers.bls.keystore.KeyStore;
+import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
+import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+
+import com.google.common.io.Files;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext;
+
+public class ArtifactSignerFactory {
+
+  private final LabelledMetric<OperationTimer> privateKeyRetrievalTimer;
+  private Path configsDirectory;
+
+  public ArtifactSignerFactory(final Path configsDirectory, final MetricsSystem metricsSystem) {
+    this.configsDirectory = configsDirectory;
+    privateKeyRetrievalTimer =
+        metricsSystem.createLabelledTimer(
+            Eth2SignerMetricCategory.SIGNING,
+            "private_key_time",
+            "Time taken to retrieve private key",
+            "signer");
+  }
+
+  public ArtifactSigner create(final FileRawSigningMetadata fileRawSigningMetadata) {
+    try (TimingContext timingContext = privateKeyRetrievalTimer.labels("file-raw").startTimer()) {
+      return new ArtifactSigner(new KeyPair(fileRawSigningMetadata.getPrivateKey()));
+    }
+  }
+
+  public ArtifactSigner create(final FileKeyStoreMetadata fileKeyStoreMetadata) {
+    try (TimingContext timingContext =
+        privateKeyRetrievalTimer.labels("file-keystore").startTimer()) {
+      return createKeystoreArtifact(fileKeyStoreMetadata);
+    }
+  }
+
+  private ArtifactSigner createKeystoreArtifact(final FileKeyStoreMetadata fileKeyStoreMetadata) {
+    final Path keystoreFile = makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystoreFile());
+    final Path keystorePasswordFile =
+        makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystorePasswordFile());
+    try {
+      final KeyStoreData keyStoreData = KeyStoreLoader.loadFromFile(keystoreFile);
+      final String password = loadPassword(keystorePasswordFile);
+      final Bytes privateKey = KeyStore.decrypt(password, keyStoreData);
+      final KeyPair keyPair = new KeyPair(SecretKey.fromBytes(privateKey));
+      return new ArtifactSigner(keyPair);
+    } catch (final KeyStoreValidationException e) {
+      throw new IllegalArgumentException(e.getMessage(), e);
+    }
+  }
+
+  private String loadPassword(final Path passwordFile) {
+    final String password;
+    try {
+      password = Files.asCharSource(passwordFile.toFile(), UTF_8).readFirstLine();
+      if (password == null || password.isBlank()) {
+        throw new IllegalArgumentException("Keystore password cannot be empty: " + passwordFile);
+      }
+    } catch (final FileNotFoundException e) {
+      throw new IllegalArgumentException("Keystore password file not found: " + passwordFile, e);
+    } catch (final IOException e) {
+      final String errorMessage =
+          format(
+              "Unexpected IO error while reading keystore password file [%s]: %s",
+              passwordFile, e.getMessage());
+      throw new UncheckedIOException(errorMessage, e);
+    }
+    return password;
+  }
+
+  private Path makeRelativePathAbsolute(final Path path) {
+    if (path.isAbsolute()) {
+      return path;
+    }
+
+    return configsDirectory.resolve(path);
+  }
+}

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -78,12 +78,12 @@ public class ArtifactSignerFactory {
   }
 
   private String loadPassword(final Path passwordFile) {
-    final String password;
     try {
-      password = Files.asCharSource(passwordFile.toFile(), UTF_8).readFirstLine();
+      final String password = Files.asCharSource(passwordFile.toFile(), UTF_8).readFirstLine();
       if (password == null || password.isBlank()) {
         throw new SigningMetadataException("Keystore password cannot be empty: " + passwordFile);
       }
+      return password;
     } catch (final FileNotFoundException e) {
       throw new SigningMetadataException("Keystore password file not found: " + passwordFile, e);
     } catch (final IOException e) {
@@ -93,7 +93,6 @@ public class ArtifactSignerFactory {
               passwordFile, e.getMessage());
       throw new SigningMetadataException(errorMessage, e);
     }
-    return password;
   }
 
   private Path makeRelativePathAbsolute(final Path path) {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileKeyStoreMetadata.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileKeyStoreMetadata.java
@@ -13,25 +13,33 @@
 package tech.pegasys.eth2signer.core.multikey.metadata;
 
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
-import tech.pegasys.eth2signer.crypto.SecretKey;
+
+import java.nio.file.Path;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FileRawSigningMetadata implements SigningMetadata {
+public class FileKeyStoreMetadata implements SigningMetadata {
 
-  private final SecretKey privateKey;
+  private final Path keystoreFile;
+  private final Path keystorePasswordFile;
 
-  public FileRawSigningMetadata(
-      @JsonProperty(value = "privateKey", required = true) SecretKey privateKey) {
-    this.privateKey = privateKey;
+  public FileKeyStoreMetadata(
+      @JsonProperty(value = "keystoreFile", required = true) final Path keystoreFile,
+      @JsonProperty(value = "keystorePasswordFile", required = true) Path keystorePasswordFile) {
+    this.keystoreFile = keystoreFile;
+    this.keystorePasswordFile = keystorePasswordFile;
   }
 
   @Override
-  public ArtifactSigner createSigner(final ArtifactSignerFactory factory) {
-    return factory.create(this);
+  public ArtifactSigner createSigner(final ArtifactSignerFactory artifactSignerFactory) {
+    return artifactSignerFactory.create(this);
   }
 
-  public SecretKey getPrivateKey() {
-    return privateKey;
+  public Path getKeystoreFile() {
+    return keystoreFile;
+  }
+
+  public Path getKeystorePasswordFile() {
+    return keystorePasswordFile;
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/SigningMetadata.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/SigningMetadata.java
@@ -20,8 +20,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
-@JsonSubTypes({@Type(value = FileRawSigningMetadata.class, name = "file-raw")})
+@JsonSubTypes({
+  @Type(value = FileRawSigningMetadata.class, name = "file-raw"),
+  @Type(value = FileKeyStoreMetadata.class, name = "file-keystore")
+})
 public interface SigningMetadata {
 
-  ArtifactSigner createSigner();
+  ArtifactSigner createSigner(ArtifactSignerFactory factory);
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/SigningMetadataException.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/SigningMetadataException.java
@@ -17,4 +17,8 @@ public class SigningMetadataException extends RuntimeException {
   public SigningMetadataException(final String message, final Throwable cause) {
     super(message, cause);
   }
+
+  public SigningMetadataException(final String message) {
+    super(message);
+  }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SignerParser.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SignerParser.java
@@ -10,8 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.eth2signer.core.multikey.metadata;
+package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import java.nio.file.Path;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
@@ -10,8 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.eth2signer.core.multikey.metadata;
+package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.crypto.SecretKey;
 
 import java.io.IOException;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParser.java
@@ -10,8 +10,11 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.eth2signer.core.multikey.metadata;
+package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
+import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadata;
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import java.io.FileNotFoundException;
@@ -22,18 +25,23 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class YamlSignerParser implements SignerParser {
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper(new YAMLFactory()).registerModule(new SigningMetadataModule());
-  public static final String YAML_FILE_EXTENSION = "yaml";
+  final ArtifactSignerFactory artifactSignerFactory;
+
+  public YamlSignerParser(final Path configDirectory, final MetricsSystem metricsSystem) {
+    artifactSignerFactory = new ArtifactSignerFactory(configDirectory, metricsSystem);
+  }
 
   @Override
   public ArtifactSigner parse(final Path metadataPath) {
     try {
       final SigningMetadata metaDataInfo =
           OBJECT_MAPPER.readValue(metadataPath.toFile(), SigningMetadata.class);
-      return metaDataInfo.createSigner();
+      return metaDataInfo.createSigner(artifactSignerFactory);
     } catch (final JsonParseException | JsonMappingException e) {
       throw new SigningMetadataException(
           "Invalid signing metadata file format: " + e.getMessage(), e);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParser.java
@@ -25,15 +25,14 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class YamlSignerParser implements SignerParser {
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper(new YAMLFactory()).registerModule(new SigningMetadataModule());
   final ArtifactSignerFactory artifactSignerFactory;
 
-  public YamlSignerParser(final Path configDirectory, final MetricsSystem metricsSystem) {
-    artifactSignerFactory = new ArtifactSignerFactory(configDirectory, metricsSystem);
+  public YamlSignerParser(final ArtifactSignerFactory artifactSignerFactory) {
+    this.artifactSignerFactory = artifactSignerFactory;
   }
 
   @Override

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -18,8 +18,8 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.eth2signer.core.multikey.metadata.SignerParser;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
+import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.crypto.KeyPair;
 import tech.pegasys.eth2signer.crypto.SecretKey;

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactoryTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactoryTest.java
@@ -1,5 +1,124 @@
-import static org.junit.jupiter.api.Assertions.*;
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.multikey.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.common.io.Resources;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class ArtifactSignerFactoryTest {
 
+  private static final String PUBLIC_KEY =
+      "95e57532ede3c1dd879061153f9cfdcdefa9dc5fb9c954a6677bc6641b8d26e39f70b660bbaa732c47277c0096e11400";
+  private static final String KEYSTORE_FILE = "keystore.json";
+  private static final String PASSWORD_FILE = "keystore.password";
+
+  @TempDir Path configDir;
+  private Path keystoreFile;
+  private Path passwordFile;
+  private ArtifactSignerFactory artifactSignerFactory;
+
+  @BeforeEach
+  void setup() throws IOException {
+    keystoreFile = configDir.resolve(KEYSTORE_FILE);
+    passwordFile = configDir.resolve(PASSWORD_FILE);
+    Files.copy(Path.of(Resources.getResource(KEYSTORE_FILE).getPath()), keystoreFile);
+    Files.copy(Path.of(Resources.getResource(PASSWORD_FILE).getPath()), passwordFile);
+
+    artifactSignerFactory = new ArtifactSignerFactory(configDir, new NoOpMetricsSystem());
+  }
+
+  @Test
+  void createsArtifactSignerFromKeyStoreUsingRelativePaths() {
+    final Path relativeKeystorePath = Path.of(KEYSTORE_FILE);
+    final Path relativePasswordPath = Path.of(PASSWORD_FILE);
+    final ArtifactSigner artifactSigner =
+        artifactSignerFactory.create(
+            new FileKeyStoreMetadata(relativeKeystorePath, relativePasswordPath));
+
+    assertThat(relativeKeystorePath).isRelative();
+    assertThat(relativePasswordPath).isRelative();
+    assertThat(artifactSigner.getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+  }
+
+  @Test
+  void createsArtifactSignerFromKeyStoreUsingAbsolutePaths() {
+
+    final ArtifactSigner artifactSigner =
+        artifactSignerFactory.create(new FileKeyStoreMetadata(keystoreFile, passwordFile));
+
+    assertThat(keystoreFile).isAbsolute();
+    assertThat(passwordFile).isAbsolute();
+    assertThat(artifactSigner.getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+  }
+
+  @Test
+  void nonExistentKeyStoreThrowsError() {
+    final Path nonExistingKeystoreFile = configDir.resolve("someNonExistingKeystore");
+    final FileKeyStoreMetadata fileKeyStoreMetadata =
+        new FileKeyStoreMetadata(nonExistingKeystoreFile, passwordFile);
+
+    assertThatThrownBy(() -> artifactSignerFactory.create(fileKeyStoreMetadata))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessage("KeyStore file not found: " + nonExistingKeystoreFile);
+  }
+
+  @Test
+  void invalidKeystorePasswordThrowsError() throws IOException {
+    final Path invalidPasswordFile = configDir.resolve("invalidPassword");
+    Files.writeString(invalidPasswordFile, "invalid_password");
+
+    final FileKeyStoreMetadata fileKeyStoreMetadata =
+        new FileKeyStoreMetadata(keystoreFile, invalidPasswordFile);
+
+    assertThatThrownBy(() -> artifactSignerFactory.create(fileKeyStoreMetadata))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessage("Failed to decrypt KeyStore, checksum validation failed.");
+  }
+
+  @Test
+  void emptyKeystorePasswordThrowsError() throws IOException {
+    final Path emptyPasswordFile = configDir.resolve("emptyPassword");
+    Files.createFile(emptyPasswordFile);
+
+    final FileKeyStoreMetadata fileKeyStoreMetadata =
+        new FileKeyStoreMetadata(keystoreFile, emptyPasswordFile);
+
+    assertThatThrownBy(() -> artifactSignerFactory.create(fileKeyStoreMetadata))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessage("Keystore password cannot be empty: " + emptyPasswordFile);
+  }
+
+  @Test
+  void nonExistentKeystorePasswordThrowsError() throws IOException {
+    final Path nonExistentPassword = configDir.resolve("nonExistentPassword");
+
+    final FileKeyStoreMetadata fileKeyStoreMetadata =
+        new FileKeyStoreMetadata(keystoreFile, nonExistentPassword);
+
+    assertThatThrownBy(() -> artifactSignerFactory.create(fileKeyStoreMetadata))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessage("Keystore password file not found: " + nonExistentPassword);
+  }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
@@ -14,8 +14,8 @@ package tech.pegasys.eth2signer.core.multikey.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static tech.pegasys.eth2signer.core.multikey.metadata.YamlSignerParser.YAML_FILE_EXTENSION;
 
+import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import java.io.IOException;
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class YamlSignerParserTest {
+
+  private static final String YAML_FILE_EXTENSION = "yaml";
   private static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
   private static final String PRIVATE_KEY =
       "000000000000000000000000000000003ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
@@ -45,7 +48,7 @@ class YamlSignerParserTest {
 
   @BeforeEach
   public void setup() {
-    signerParser = new YamlSignerParser();
+    signerParser = new YamlSignerParser(Path.of("."), new NoOpMetricsSystem());
   }
 
   @Test

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
@@ -14,9 +14,15 @@ package tech.pegasys.eth2signer.core.multikey.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.crypto.KeyPair;
+import tech.pegasys.eth2signer.crypto.SecretKey;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,11 +31,12 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,13 +50,13 @@ class YamlSignerParserTest {
       "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
 
   @TempDir Path configDir;
+  @Mock private ArtifactSignerFactory artifactSignerFactory;
 
   private YamlSignerParser signerParser;
-  private String YAML_FILE_EXTENSION = "yaml";
 
   @BeforeEach
   public void setup() {
-    signerParser = new YamlSignerParser(Path.of("."), new NoOpMetricsSystem());
+    signerParser = new YamlSignerParser(artifactSignerFactory);
   }
 
   @Test
@@ -106,6 +113,11 @@ class YamlSignerParserTest {
 
   @Test
   void unencryptedMetaDataInfoWithPrivateKeyReturnsMetadata() throws IOException {
+    final ArtifactSigner artifactSigner =
+        new ArtifactSigner(new KeyPair(SecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY))));
+    when(artifactSignerFactory.create(any(FileRawSigningMetadata.class)))
+        .thenReturn(artifactSigner);
+
     final Path filename = configDir.resolve("unencrypted." + YAML_FILE_EXTENSION);
     final Map<String, String> unencryptedKeyMetadataFile = new HashMap<>();
     unencryptedKeyMetadataFile.put("type", "file-raw");
@@ -114,11 +126,17 @@ class YamlSignerParserTest {
 
     final ArtifactSigner result = signerParser.parse(filename);
 
-    assertThat(result.getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(result).isEqualTo(artifactSigner);
+    verify(artifactSignerFactory).create(hasPrivateKey(PRIVATE_KEY));
   }
 
   @Test
   void unencryptedMetaDataInfoWith0xPrefixPrivateKeyReturnsMetadata() throws IOException {
+    final ArtifactSigner artifactSigner =
+        new ArtifactSigner(new KeyPair(SecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY))));
+    when(artifactSignerFactory.create(any(FileRawSigningMetadata.class)))
+        .thenReturn(artifactSigner);
+
     final Path filename = configDir.resolve("unencrypted." + YAML_FILE_EXTENSION);
     final Map<String, String> unencryptedKeyMetadataFile = new HashMap<>();
     unencryptedKeyMetadataFile.put("type", "file-raw");
@@ -127,6 +145,85 @@ class YamlSignerParserTest {
 
     final ArtifactSigner result = signerParser.parse(filename);
 
-    assertThat(result.getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(result).isEqualTo(artifactSigner);
+    verify(artifactSignerFactory).create(hasPrivateKey(PRIVATE_KEY));
+  }
+
+  @Test
+  void keyStoreMetaDataInfoWithMissingAllFilesFails() throws IOException {
+    final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
+    YAML_OBJECT_MAPPER.writeValue(filename.toFile(), Map.of("type", "file-keystore"));
+
+    assertThatThrownBy(() -> signerParser.parse(filename))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessageStartingWith(
+            "Invalid signing metadata file format: Missing required creator property 'keystoreFile'");
+  }
+
+  @Test
+  void keyStoreMetaDataInfoWithMissingKeystoreFilesFails() throws IOException {
+    final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
+    final Path passwordFile = configDir.resolve("keystore.password");
+
+    final Map<String, String> keystoreMetadataFile = new HashMap<>();
+    keystoreMetadataFile.put("type", "file-keystore");
+    keystoreMetadataFile.put("keystorePasswordFile", passwordFile.toString());
+    YAML_OBJECT_MAPPER.writeValue(filename.toFile(), keystoreMetadataFile);
+
+    assertThatThrownBy(() -> signerParser.parse(filename))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessageStartingWith(
+            "Invalid signing metadata file format: Missing required creator property 'keystoreFile'");
+  }
+
+  @Test
+  void keyStoreMetaDataInfoWithMissingPasswordFilesFails() throws IOException {
+    final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
+    final Path keystoreFile = configDir.resolve("keystore.json");
+
+    final Map<String, String> keystoreMetadataFile = new HashMap<>();
+    keystoreMetadataFile.put("type", "file-keystore");
+    keystoreMetadataFile.put("keystoreFile", keystoreFile.toString());
+    YAML_OBJECT_MAPPER.writeValue(filename.toFile(), keystoreMetadataFile);
+
+    assertThatThrownBy(() -> signerParser.parse(filename))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessageStartingWith(
+            "Invalid signing metadata file format: Missing required creator property 'keystorePasswordFile'");
+  }
+
+  @Test
+  void keyStoreMetaDataInfoReturnsMetadata() throws IOException {
+    final ArtifactSigner artifactSigner =
+        new ArtifactSigner(new KeyPair(SecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY))));
+    when(artifactSignerFactory.create(any(FileKeyStoreMetadata.class))).thenReturn(artifactSigner);
+
+    final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
+    final Path keystoreFile = configDir.resolve("keystore.json");
+    final Path passwordFile = configDir.resolve("keystore.password");
+
+    final Map<String, String> keystoreMetadataFile = new HashMap<>();
+    keystoreMetadataFile.put("type", "file-keystore");
+    keystoreMetadataFile.put("keystoreFile", keystoreFile.toString());
+    keystoreMetadataFile.put("keystorePasswordFile", passwordFile.toString());
+    YAML_OBJECT_MAPPER.writeValue(filename.toFile(), keystoreMetadataFile);
+
+    final ArtifactSigner result = signerParser.parse(filename);
+    assertThat(result).isEqualTo(artifactSigner);
+    verify(artifactSignerFactory).create(hasKeystoreAndPasswordFile(keystoreFile, passwordFile));
+  }
+
+  private FileKeyStoreMetadata hasKeystoreAndPasswordFile(
+      final Path keystoreFile, final Path passwordFile) {
+    return argThat(
+        (FileKeyStoreMetadata m) ->
+            m.getKeystoreFile().equals(keystoreFile)
+                && m.getKeystorePasswordFile().equals(passwordFile));
+  }
+
+  private FileRawSigningMetadata hasPrivateKey(final String privateKey) {
+    final Bytes privateKeyBytes = Bytes.fromHexString(privateKey);
+    return argThat(
+        (FileRawSigningMetadata m) -> m.getPrivateKey().toBytes().equals(privateKeyBytes));
   }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/YamlSignerParserTest.java
@@ -46,8 +46,6 @@ class YamlSignerParserTest {
   private static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
   private static final String PRIVATE_KEY =
       "000000000000000000000000000000003ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
-  private static final String PUBLIC_KEY =
-      "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
 
   @TempDir Path configDir;
   @Mock private ArtifactSignerFactory artifactSignerFactory;

--- a/core/src/test/resources/keystore.json
+++ b/core/src/test/resources/keystore.json
@@ -1,0 +1,31 @@
+{
+  "crypto" : {
+    "kdf" : {
+      "function" : "scrypt",
+      "params" : {
+        "dklen" : 32,
+        "n" : 262144,
+        "p" : 1,
+        "r" : 8,
+        "salt" : "1f2b6d2bac495b05ec65f49e8d9def356b29b65a0b80260a884d6d393073ff7b"
+      },
+      "message" : ""
+    },
+    "checksum" : {
+      "function" : "sha256",
+      "params" : { },
+      "message" : "0758d6efc78b312d84395467ac96b8224b6e064050de0322f0d08fe9a047abea"
+    },
+    "cipher" : {
+      "function" : "aes-128-ctr",
+      "params" : {
+        "iv" : "e0f20a27d160f7cc92764579390e881a"
+      },
+      "message" : "08d8366ec551863e87a80e53cb1bc1c4ebf6a26b245161dcaae3ee6ae791979030d495f752428702bc849eb03f62eec2"
+    }
+  },
+  "pubkey" : "95e57532ede3c1dd879061153f9cfdcdefa9dc5fb9c954a6677bc6641b8d26e39f70b660bbaa732c47277c0096e11400",
+  "path" : "",
+  "uuid" : "39ce1e14-50c9-449d-aded-004ec41f1fb8",
+  "version" : 4
+}

--- a/core/src/test/resources/keystore.password
+++ b/core/src/test/resources/keystore.password
@@ -1,0 +1,1 @@
+testpassword

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -70,5 +70,7 @@ dependencyManagement {
 
     dependency 'org.hyperledger.besu.internal:metrics-core:1.4.0'
     dependency 'org.hyperledger.besu:plugin-api:1.4.0'
+
+    dependency 'tech.pegasys.signers.internal:bls-keystore:0.0.1-SNAPSHOT'
   }
 }


### PR DESCRIPTION
Provide capability to provide validator keys using eip-2335 keystore files and sign using them.