### PR TITLE
Include public key in url path

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
@@ -103,14 +103,14 @@ public class Signer {
   public HttpResponse signData(
       final String endpoint, final BLSPublicKey publicKey, final Bytes signingRoot)
       throws ExecutionException, InterruptedException {
-    final SigningRequestBody requestBody =
-        new SigningRequestBody(publicKey.toString(), signingRoot.toHexString());
+    final String url = endpoint + "/" + publicKey;
+    final SigningRequestBody requestBody = new SigningRequestBody(signingRoot.toHexString());
     final String httpBody = Json.encode(requestBody);
 
     final CompletableFuture<HttpResponse> responseBodyFuture = new CompletableFuture<>();
     final HttpClientRequest request =
         httpClient.post(
-            endpoint,
+            url,
             response ->
                 response.bodyHandler(
                     body ->

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -105,7 +105,12 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   public void receiveA400IfJsonBodyIsMalformed() throws Exception {
+    final String configFilename = keyPair.getPublicKey().toString().substring(2);
+    final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
+    metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
+
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
+    builder.withKeyStoreDirectory(testDirectory);
     startSigner(builder.build());
 
     final String endpoint = "/signer/block/" + keyPair.getPublicKey().toString();

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -108,7 +108,8 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     startSigner(builder.build());
 
-    final HttpResponse response = signer.postRawRequest("/signer/block/", "invalid Body");
+    final String endpoint = "/signer/block/" + keyPair.getPublicKey().toString();
+    final HttpResponse response = signer.postRawRequest(endpoint, "invalid Body");
     assertThat(response.getStatusCode()).isEqualTo(400);
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -108,7 +108,7 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
     startSigner(builder.build());
 
-    final HttpResponse response = signer.postRawRequest("/signer/block", "invalid Body");
+    final HttpResponse response = signer.postRawRequest("/signer/block/", "invalid Body");
     assertThat(response.getStatusCode()).isEqualTo(400);
   }
 
@@ -129,7 +129,8 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
 
     final String httpBody = Json.encode(requestBody);
 
-    final HttpResponse response = signer.postRawRequest("/signer/block", httpBody);
+    final String endpoint = "/signer/block/" + keyPair.getPublicKey().toString();
+    final HttpResponse response = signer.postRawRequest(endpoint, httpBody);
     assertThat(response.getStatusCode()).isEqualTo(HttpResponseStatus.OK.code());
   }
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.eth2signer.core;
 
+import static tech.pegasys.eth2signer.core.http.SigningRequestHandler.SIGNER_PATH_REGEX;
+
 import tech.pegasys.eth2signer.core.http.LogErrorHandler;
 import tech.pegasys.eth2signer.core.http.SigningRequestHandler;
 import tech.pegasys.eth2signer.core.metrics.MetricsEndpoint;
@@ -120,7 +122,7 @@ public class Runner implements Runnable {
         new SigningRequestHandler(signerProvider, createJsonDecoder());
 
     router
-        .routeWithRegex(HttpMethod.POST, "/signer/" + "(attestation|block|randao_reveal)/(.*)")
+        .routeWithRegex(HttpMethod.POST, SIGNER_PATH_REGEX)
         .produces(JSON)
         .handler(BodyHandler.create())
         .blockingHandler(signingHandler)

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -120,7 +120,7 @@ public class Runner implements Runnable {
         new SigningRequestHandler(signerProvider, createJsonDecoder());
 
     router
-        .routeWithRegex(HttpMethod.POST, "/signer/" + "(attestation|block|randao_reveal)")
+        .routeWithRegex(HttpMethod.POST, "/signer/" + "(attestation|block|randao_reveal)/(.*)")
         .produces(JSON)
         .handler(BodyHandler.create())
         .blockingHandler(signingHandler)

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestBody.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestBody.java
@@ -21,20 +21,11 @@ import org.apache.tuweni.bytes.Bytes;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SigningRequestBody {
 
-  private final String publicKey;
   private final Bytes signingRoot;
 
   @JsonCreator
-  public SigningRequestBody(
-      @JsonProperty("publicKey") final String publicKey,
-      @JsonProperty("signingRoot") final String signingRoot) {
-    this.publicKey = publicKey;
+  public SigningRequestBody(@JsonProperty("signingRoot") final String signingRoot) {
     this.signingRoot = Bytes.fromHexString(signingRoot);
-  }
-
-  @JsonGetter("publicKey")
-  public String publicKey() {
-    return publicKey;
   }
 
   public Bytes signingRoot() {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
@@ -30,6 +30,8 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class SigningRequestHandler implements Handler<RoutingContext> {
 
+  public static final String SIGNER_PATH_REGEX =
+      "/signer/(?<signerType>attestation|block|randao_reveal)/(?<publicKey>.*)";
   private static final Logger LOG = LogManager.getLogger();
   private final ArtifactSignerProvider signerProvider;
   private final JsonDecoder jsonDecoder;
@@ -43,7 +45,7 @@ public class SigningRequestHandler implements Handler<RoutingContext> {
   @Override
   public void handle(final RoutingContext context) {
     LOG.debug("Received a request for {}", context.normalisedPath());
-    final String publicKey = context.pathParam("param1");
+    final String publicKey = context.pathParam("publicKey");
     generateResponseFromBody(context.response(), context.getBody(), publicKey);
   }
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
@@ -10,11 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.eth2signer.core.multikey.metadata;
+package tech.pegasys.eth2signer.core.multikey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
+import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
+import tech.pegasys.eth2signer.core.multikey.metadata.HashicorpSigningMetadata;
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.eth2signer.core.multikey.metadata;
+package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -21,7 +21,10 @@ import static org.mockito.Mockito.when;
 
 import tech.pegasys.artemis.util.bls.BLSKeyPair;
 import tech.pegasys.artemis.util.bls.BLSSecretKey;
-import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
+import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
+import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
+import tech.pegasys.eth2signer.core.multikey.metadata.FileRawSigningMetadata;
+import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import java.io.IOException;


### PR DESCRIPTION
Includes public key in url path so that the API can be more easily used by load balancers.

See issue https://github.com/PegaSysEng/eth2signer/issues/49

This will update the API to be:
```
/signer/block/<publickey>
/signer/attestation/<publickey>
/signer/randao_reveal/<publickey>
```

```
{
	“signingRoot”: <hex encoded string>
}
```