### PR TITLE
Cache signing keys

### DIFF
--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
@@ -71,6 +71,13 @@ public class Eth2SignerCommand implements Config, Runnable {
   private Path keyStorePath = Path.of("./");
 
   @Option(
+      names = {"--key-cache-limit"},
+      description =
+          "The maximum number of keys that will be cached in memory (default: ${DEFAULT-VALUE})",
+      paramLabel = DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP)
+  private Long keyCacheLimit = 1000L;
+
+  @Option(
       names = {"--logging", "-l"},
       paramLabel = "<LOG VERBOSITY LEVEL>",
       description =
@@ -165,6 +172,11 @@ public class Eth2SignerCommand implements Config, Runnable {
   @Override
   public Set<MetricCategory> getMetricCategories() {
     return metricCategories;
+  }
+
+  @Override
+  public Long getKeyCacheLimit() {
+    return keyCacheLimit;
   }
 
   @Override

--- a/core/src/integrationTest/java/tech/pegasys/eth2signer/core/DirectoryBackedArtifactSigningProviderIntegrationTest.java
+++ b/core/src/integrationTest/java/tech/pegasys/eth2signer/core/DirectoryBackedArtifactSigningProviderIntegrationTest.java
@@ -46,13 +46,10 @@ import org.junit.jupiter.api.io.TempDir;
 public class DirectoryBackedArtifactSigningProviderIntegrationTest {
 
   @TempDir Path configsDirectory;
-  private SignerParser signerParser;
   private static final String FILE_EXTENSION = "yaml";
   private static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
   private DirectoryBackedArtifactSignerProvider signerProvider;
-  private ArtifactSignerFactory artifactSignerFactory;
-  private HashicorpConnectionFactory hashicorpConnectionFactory;
   private Vertx vertx;
   private TrackingLogAppender logAppender = new TrackingLogAppender();
   private final Logger logger =
@@ -64,14 +61,16 @@ public class DirectoryBackedArtifactSigningProviderIntegrationTest {
   @BeforeEach
   void setup() {
     vertx = Vertx.vertx();
-    hashicorpConnectionFactory = new HashicorpConnectionFactory(vertx);
+    final HashicorpConnectionFactory hashicorpConnectionFactory =
+        new HashicorpConnectionFactory(vertx);
 
-    artifactSignerFactory =
+    final ArtifactSignerFactory artifactSignerFactory =
         new ArtifactSignerFactory(
             configsDirectory, new NoOpMetricsSystem(), hashicorpConnectionFactory);
-    signerParser = new YamlSignerParser(artifactSignerFactory);
+    final SignerParser signerParser = new YamlSignerParser(artifactSignerFactory);
     signerProvider =
-        new DirectoryBackedArtifactSignerProvider(configsDirectory, FILE_EXTENSION, signerParser);
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 0);
 
     logAppender.start();
     logger.addAppender(logAppender);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Config.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Config.java
@@ -37,4 +37,6 @@ public interface Config {
   String getMetricsNetworkInterface();
 
   Set<MetricCategory> getMetricCategories();
+
+  Long getKeyCacheLimit();
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -21,7 +21,6 @@ import tech.pegasys.eth2signer.core.metrics.VertxMetricsAdapterFactory;
 import tech.pegasys.eth2signer.core.multikey.DirectoryBackedArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
-import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.utils.JsonDecoder;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 
@@ -100,14 +99,17 @@ public class Runner implements Runnable {
     }
   }
 
-  private SigningRequestHandler createSigningHandler(final MetricsSystem metricsSystem,
-      final Vertx vertx) {
+  private SigningRequestHandler createSigningHandler(
+      final MetricsSystem metricsSystem, final Vertx vertx) {
     final ArtifactSignerFactory artifactSignerFactory =
         new ArtifactSignerFactory(
             config.getKeyConfigPath(), metricsSystem, new HashicorpConnectionFactory(vertx));
     final DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            config.getKeyConfigPath(), "yaml", new YamlSignerParser(artifactSignerFactory));
+            config.getKeyConfigPath(),
+            "yaml",
+            new YamlSignerParser(artifactSignerFactory),
+            config.getKeyCacheLimit());
 
     final SigningRequestHandler signingHandler =
         new SigningRequestHandler(signerProvider, createJsonDecoder());

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -35,6 +35,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -68,8 +69,12 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
     final ArtifactSigner signer;
     try {
       signer = artifactSignerCache.get(normalisedIdentifier);
-    } catch (NoSuchElementException e) {
-      LOG.error("No valid matching metadata file found for the identifier {}", signerIdentifier);
+    } catch (UncheckedExecutionException e) {
+      if (e.getCause() instanceof NoSuchElementException) {
+        LOG.error("No valid matching metadata file found for the identifier {}", signerIdentifier);
+      } else {
+        LOG.error("Error loading for signer for identifier {}", signerIdentifier);
+      }
       return Optional.empty();
     } catch (Exception e) {
       LOG.error("Error loading for signer for identifier {}", signerIdentifier);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.eth2signer.core.multikey;
 
+import static java.util.stream.Collectors.toMap;
+
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
@@ -24,11 +26,18 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Functions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -37,50 +46,69 @@ import org.apache.logging.log4j.Logger;
 public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProvider {
 
   private static final Logger LOG = LogManager.getLogger();
+  private static final int MAXIMUM_SIZE = 1000;
   private final Path configsDirectory;
   private final String fileExtension;
   private final SignerParser signerParser;
+  private final LoadingCache<String, ArtifactSigner> artifactSignerCache;
 
   public DirectoryBackedArtifactSignerProvider(
       final Path rootDirectory, final String fileExtension, final SignerParser signerParser) {
     this.configsDirectory = rootDirectory;
     this.fileExtension = fileExtension;
     this.signerParser = signerParser;
+    this.artifactSignerCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(MAXIMUM_SIZE)
+            .build(CacheLoader.from((i) -> loadSignerForIdentifier(i).orElseThrow()));
   }
 
   @Override
   public Optional<ArtifactSigner> getSigner(final String signerIdentifier) {
     final String normalisedIdentifier = normaliseIdentifier(signerIdentifier);
-    final Optional<ArtifactSignerWithFileName> signer =
-        loadSignerForIdentifier(normalisedIdentifier);
-    if (signer.isEmpty()) {
+    final ArtifactSigner signer;
+    try {
+      signer = artifactSignerCache.get(normalisedIdentifier);
+    } catch (NoSuchElementException e) {
       LOG.error("No valid matching metadata file found for the identifier {}", signerIdentifier);
       return Optional.empty();
-    }
-    final ArtifactSignerWithFileName signerWithFileName = signer.get();
-    if (!signerMatchesIdentifier(signerWithFileName, signerIdentifier)) {
-      LOG.error(
-          "Signing metadata file {} does not correspond to the specified signer identifier {}",
-          signerWithFileName.getPath().getFileName(),
-          signerWithFileName.getSigner().getIdentifier());
+    } catch (Exception e) {
+      LOG.error("Error loading for signer for identifier {}", signerIdentifier);
       return Optional.empty();
     }
-    return signer.map(ArtifactSignerWithFileName::getSigner);
+
+    if (!signerMatchesIdentifier(signer, signerIdentifier)) {
+      LOG.error(
+          "Signing metadata config does not correspond to the specified signer identifier {}",
+          signer.getIdentifier());
+      return Optional.empty();
+    }
+    return Optional.of(signer);
   }
 
   @Override
   public Set<String> availableIdentifiers() {
     return loadAvailableSigners().stream()
         .filter(Objects::nonNull)
-        .map(ArtifactSignerWithFileName::getSigner)
         .map(ArtifactSigner::getIdentifier)
         .collect(Collectors.toSet());
   }
 
-  private Optional<ArtifactSignerWithFileName> loadSignerForIdentifier(
-      final String signerIdentifier) {
+  public void cacheAllSigners() {
+    final Map<String, ArtifactSigner> signersByIdentifier =
+        loadAvailableSigners().stream()
+            .collect(toMap(ArtifactSigner::getIdentifier, Functions.identity()));
+    artifactSignerCache.putAll(signersByIdentifier);
+  }
+
+  @VisibleForTesting
+  protected LoadingCache<String, ArtifactSigner> getArtifactSignerCache() {
+    return artifactSignerCache;
+  }
+
+  private Optional<ArtifactSigner> loadSignerForIdentifier(final String signerIdentifier) {
     final Filter<Path> pathFilter = signerIdentifierFilenameFilter(signerIdentifier);
-    final Collection<ArtifactSignerWithFileName> matchingSigners = findSigners(pathFilter);
+    final Collection<ArtifactSigner> matchingSigners = findSigners(pathFilter);
     if (matchingSigners.size() > 1) {
       LOG.error(
           "Found multiple signing metadata file matches for signer identifier " + signerIdentifier);
@@ -92,21 +120,20 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
     }
   }
 
-  private Collection<ArtifactSignerWithFileName> loadAvailableSigners() {
+  private Collection<ArtifactSigner> loadAvailableSigners() {
     return findSigners(this::matchesFileExtension);
   }
 
-  private Collection<ArtifactSignerWithFileName> findSigners(
+  private Collection<ArtifactSigner> findSigners(
       final DirectoryStream.Filter<? super Path> filter) {
-    final Collection<ArtifactSignerWithFileName> signers = new HashSet<>();
+    final Collection<ArtifactSigner> signers = new HashSet<>();
 
     try (final DirectoryStream<Path> directoryStream =
         Files.newDirectoryStream(configsDirectory, filter)) {
       for (final Path file : directoryStream) {
         try {
-          final ArtifactSignerWithFileName artifactSignerWithFileName =
-              new ArtifactSignerWithFileName(file, signerParser.parse(file));
-          signers.add(artifactSignerWithFileName);
+          final ArtifactSigner artifactSigner = signerParser.parse(file);
+          signers.add(artifactSigner);
         } catch (Exception e) {
           renderException(e, file.getFileName().toString());
         }
@@ -132,8 +159,8 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
   }
 
   private boolean signerMatchesIdentifier(
-      final ArtifactSignerWithFileName signerWithFileName, final String signerIdentifier) {
-    final String identifier = signerWithFileName.getSigner().getIdentifier();
+      final ArtifactSigner signer, final String signerIdentifier) {
+    final String identifier = signer.getIdentifier();
     return normaliseIdentifier(identifier).equalsIgnoreCase(normaliseIdentifier(signerIdentifier));
   }
 
@@ -141,25 +168,6 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
     return signerIdentifier.toLowerCase().startsWith("0x")
         ? signerIdentifier.substring(2)
         : signerIdentifier;
-  }
-
-  private static class ArtifactSignerWithFileName {
-
-    private final Path path;
-    private final ArtifactSigner signer;
-
-    public ArtifactSignerWithFileName(final Path path, final ArtifactSigner signer) {
-      this.path = path;
-      this.signer = signer;
-    }
-
-    public Path getPath() {
-      return path;
-    }
-
-    public ArtifactSigner getSigner() {
-      return signer;
-    }
   }
 
   private void renderException(final Throwable t, final String filename) {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.multikey;
 
+import java.util.concurrent.ExecutionException;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
@@ -91,6 +92,14 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
         .filter(Objects::nonNull)
         .map(identifier -> "0x" + normaliseIdentifier(identifier))
         .collect(Collectors.toSet());
+  }
+
+  public void cacheAllSigners() {
+    try {
+      artifactSignerCache.getAll(availableIdentifiers());
+    } catch (ExecutionException e) {
+      LOG.error("Error loading cache with signers", e);
+    }
   }
 
   @VisibleForTesting

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -72,7 +72,7 @@ class DirectoryBackedArtifactSignerProviderTest {
   void setup() {
     signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            configsDirectory, FILE_EXTENSION, signerParser, 5);
+            configsDirectory, FILE_EXTENSION, signerParser, 0);
   }
 
   @Test
@@ -258,7 +258,10 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   @Test
-  void signerLoadedIntoCacheForValidMetadataFile() throws IOException, ExecutionException {
+  void signerLoadedIntoCacheForValidMetadataFile() throws IOException {
+    DirectoryBackedArtifactSignerProvider signerProvider =
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 1);
     createFileInConfigsDirectory(PUBLIC_KEY1);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
     final String identifier = "0x" + PUBLIC_KEY1;
@@ -296,6 +299,9 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void signerCacheIsUsedIfAlreadyInCache() {
+    DirectoryBackedArtifactSignerProvider signerProvider =
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 1);
     final String identifier = "0x" + PUBLIC_KEY1;
     final LoadingCache<String, ArtifactSigner> artifactSignerCache =
         signerProvider.getArtifactSignerCache();
@@ -344,6 +350,9 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void cacheAllSignersPopulatesCacheForAllIdentifiers() throws IOException {
+    DirectoryBackedArtifactSignerProvider signerProvider =
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 3);
     createFileInConfigsDirectory(PUBLIC_KEY1);
     createFileInConfigsDirectory(PUBLIC_KEY2);
     createFileInConfigsDirectory(PUBLIC_KEY3);

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -52,51 +52,60 @@ class DirectoryBackedArtifactSignerProviderTest {
   @Mock private SignerParser signerParser;
 
   private static final String FILE_EXTENSION = "yaml";
-  private static final String PUBLIC_KEY =
+  private static final String PUBLIC_KEY1 =
       "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
-  private static final String PRIVATE_KEY =
+  private static final String PRIVATE_KEY1 =
       "3ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
+  private static final String PUBLIC_KEY2 =
+      "a99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c";
+  private static final String PRIVATE_KEY2 =
+      "25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866";
+  private static final String PUBLIC_KEY3 =
+      "a3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b";
+  private static final String PRIVATE_KEY3 =
+      "315ed405fafe339603932eebe8dbfd650ce5dafa561f6928664c75db85f97857";
 
-  private ArtifactSigner artifactSigner = createArtifactSigner(PRIVATE_KEY);
+  private ArtifactSigner artifactSigner = createArtifactSigner(PRIVATE_KEY1);
   private DirectoryBackedArtifactSignerProvider signerProvider;
 
   @BeforeEach
   void setup() {
     signerProvider =
-        new DirectoryBackedArtifactSignerProvider(configsDirectory, FILE_EXTENSION, signerParser);
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 5);
   }
 
   @Test
   void signerReturnedForValidMetadataFile() throws IOException {
-    final String filename = PUBLIC_KEY;
+    final String filename = PUBLIC_KEY1;
     createFileInConfigsDirectory(filename);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isNotEmpty();
-    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
     verify(signerParser).parse(pathEndsWith(filename));
   }
 
   @Test
   void signerReturnedWhenIdentifierHasCaseMismatchToFilename() throws IOException {
-    final String filename = PUBLIC_KEY.toUpperCase();
+    final String filename = PUBLIC_KEY1.toUpperCase();
     createFileInConfigsDirectory(filename);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isNotEmpty();
-    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
     verify(signerParser).parse(pathEndsWith(filename));
   }
 
   @Test
   void signerReturnedWhenHasHexPrefix() throws IOException {
-    final String metadataFilename = PUBLIC_KEY;
+    final String metadataFilename = PUBLIC_KEY1;
     createFileInConfigsDirectory(metadataFilename);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0x" + PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0x" + PUBLIC_KEY1);
 
     assertThat(signer).isNotEmpty();
     verify(signerParser).parse(pathEndsWith(metadataFilename));
@@ -104,11 +113,11 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void signerReturnedWhenHasUpperCaseHexPrefix() throws IOException {
-    final String metadataFilename = PUBLIC_KEY;
+    final String metadataFilename = PUBLIC_KEY1;
     createFileInConfigsDirectory(metadataFilename);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0X" + PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0X" + PUBLIC_KEY1);
 
     assertThat(signer).isNotEmpty();
     verify(signerParser).parse(pathEndsWith(metadataFilename));
@@ -117,15 +126,15 @@ class DirectoryBackedArtifactSignerProviderTest {
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   void signerReturnedWhenFileExtensionIsUpperCase() throws IOException {
-    final String metadataFilename = PUBLIC_KEY + ".YAML";
+    final String metadataFilename = PUBLIC_KEY1 + ".YAML";
     final File file = configsDirectory.resolve(metadataFilename).toFile();
     file.createNewFile();
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0X" + PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner("0X" + PUBLIC_KEY1);
 
     assertThat(signer).isNotEmpty();
-    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
     verify(signerParser)
         .parse(argThat((Path path) -> path != null && path.endsWith(metadataFilename)));
   }
@@ -133,21 +142,21 @@ class DirectoryBackedArtifactSignerProviderTest {
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   void wrongFileExtensionReturnsEmptySigner() throws IOException {
-    final String metadataFilename = PUBLIC_KEY + ".nothing";
+    final String metadataFilename = PUBLIC_KEY1 + ".nothing";
     final File file = configsDirectory.resolve(metadataFilename).toFile();
     file.createNewFile();
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isEmpty();
     verifyNoMoreInteractions(signerParser);
   }
 
   @Test
   void failedParserReturnsEmptySigner() throws IOException {
-    createFileInConfigsDirectory(PUBLIC_KEY);
+    createFileInConfigsDirectory(PUBLIC_KEY1);
     when(signerParser.parse(any())).thenThrow(SigningMetadataException.class);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isEmpty();
   }
 
@@ -155,45 +164,47 @@ class DirectoryBackedArtifactSignerProviderTest {
   void failedWithDirectoryErrorReturnEmptySigner() throws IOException {
     final DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
-            configsDirectory.resolve("idontexist"), FILE_EXTENSION, signerParser);
-    createFileInConfigsDirectory(PUBLIC_KEY);
+            configsDirectory.resolve("idontexist"), FILE_EXTENSION, signerParser, 5);
+    createFileInConfigsDirectory(PUBLIC_KEY1);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isEmpty();
   }
 
   @Test
   void multipleMatchesForSameIdentifierReturnsEmpty() throws IOException {
-    final String filename1 = "1_" + PUBLIC_KEY;
-    final String filename2 = "2_" + PUBLIC_KEY;
+    final String filename1 = "1_" + PUBLIC_KEY1;
+    final String filename2 = "2_" + PUBLIC_KEY1;
     createFileInConfigsDirectory(filename1);
     createFileInConfigsDirectory(filename2);
 
-    when(signerParser.parse(pathEndsWith(filename1))).thenReturn(createArtifactSigner(PRIVATE_KEY));
-    when(signerParser.parse(pathEndsWith(filename2))).thenReturn(createArtifactSigner(PRIVATE_KEY));
+    when(signerParser.parse(pathEndsWith(filename1)))
+        .thenReturn(createArtifactSigner(PRIVATE_KEY1));
+    when(signerParser.parse(pathEndsWith(filename2)))
+        .thenReturn(createArtifactSigner(PRIVATE_KEY1));
 
-    final Optional<ArtifactSigner> loadedMetadataFile = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> loadedMetadataFile = signerProvider.getSigner(PUBLIC_KEY1);
 
     assertThat(loadedMetadataFile).isEmpty();
   }
 
   @Test
   void signerReturnedForMetadataFileWithPrefix() throws IOException {
-    final String filename = "someprefix" + PUBLIC_KEY;
+    final String filename = "someprefix" + PUBLIC_KEY1;
     createFileInConfigsDirectory(filename);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isNotEmpty();
-    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY);
+    assertThat(signer.get().getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
     verify(signerParser).parse(pathEndsWith(filename));
   }
 
   @Test
   void signerIdentifiersReturnedForMetadataFile() throws IOException {
-    createFileInConfigsDirectory(PUBLIC_KEY);
+    createFileInConfigsDirectory(PUBLIC_KEY1);
 
-    assertThat(signerProvider.availableIdentifiers()).containsExactly("0x" + PUBLIC_KEY);
+    assertThat(signerProvider.availableIdentifiers()).containsExactly("0x" + PUBLIC_KEY1);
     verify(signerParser, never()).parse(any());
   }
 
@@ -235,8 +246,8 @@ class DirectoryBackedArtifactSignerProviderTest {
     logger.addAppender(logAppender);
 
     try {
-      createFileInConfigsDirectory(PUBLIC_KEY);
-      signerProvider.getSigner(PUBLIC_KEY);
+      createFileInConfigsDirectory(PUBLIC_KEY1);
+      signerProvider.getSigner(PUBLIC_KEY1);
 
       assertThat(logAppender.getLogMessagesReceived().get(0).getMessage().getFormattedMessage())
           .contains(rootCause.getMessage());
@@ -247,20 +258,108 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   @Test
-  void cachesLoadedSigner() throws IOException, ExecutionException {
-    createFileInConfigsDirectory(PUBLIC_KEY);
+  void signerLoadedIntoCacheForValidMetadataFile() throws IOException, ExecutionException {
+    createFileInConfigsDirectory(PUBLIC_KEY1);
     when(signerParser.parse(any())).thenReturn(artifactSigner);
-    final String identifier = "0x" + PUBLIC_KEY;
+    final String identifier = "0x" + PUBLIC_KEY1;
 
     assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
 
-    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY);
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isNotEmpty();
     assertThat(signer.get().getIdentifier()).isEqualTo(identifier);
 
     final LoadingCache<String, ArtifactSigner> cache = signerProvider.getArtifactSignerCache();
     assertThat(cache.size()).isEqualTo(1);
-    assertThat(cache.get(PUBLIC_KEY).getIdentifier()).isEqualTo(identifier);
+    assertThat(cache.getIfPresent(PUBLIC_KEY1).getIdentifier()).isEqualTo(identifier);
+
+    verify(signerParser).parse(pathEndsWith(PUBLIC_KEY1));
+  }
+
+  @Test
+  void signerIsNotLoadedIntoCacheWhenParserFails() throws IOException {
+    createFileInConfigsDirectory(PUBLIC_KEY1);
+    when(signerParser.parse(any())).thenThrow(SigningMetadataException.class);
+
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
+    assertThat(signer).isEmpty();
+    assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
+  }
+
+  @Test
+  void signerIsNotLoadedIntoCacheWhenNotFound() {
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
+
+    assertThat(signer).isEmpty();
+    assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
+  }
+
+  @Test
+  void signerCacheIsUsedIfAlreadyInCache() {
+    final String identifier = "0x" + PUBLIC_KEY1;
+    final LoadingCache<String, ArtifactSigner> artifactSignerCache =
+        signerProvider.getArtifactSignerCache();
+    artifactSignerCache.put(PUBLIC_KEY1, artifactSigner);
+
+    final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
+    assertThat(signer).isNotEmpty();
+    assertThat(signer.get().getIdentifier()).isEqualTo(identifier);
+    assertThat(signer.get()).isSameAs(artifactSigner);
+
+    verify(signerParser, never()).parse(any());
+  }
+
+  @Test
+  void signerCacheIsLimitedToMaxLimit() throws IOException {
+    createFileInConfigsDirectory(PUBLIC_KEY1);
+    createFileInConfigsDirectory(PUBLIC_KEY2);
+    createFileInConfigsDirectory(PUBLIC_KEY3);
+
+    final DirectoryBackedArtifactSignerProvider signerProvider =
+        new DirectoryBackedArtifactSignerProvider(
+            configsDirectory, FILE_EXTENSION, signerParser, 2);
+    final LoadingCache<String, ArtifactSigner> signerCache =
+        signerProvider.getArtifactSignerCache();
+
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY1)))
+        .thenReturn(createArtifactSigner(PRIVATE_KEY1));
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY2)))
+        .thenReturn(createArtifactSigner(PRIVATE_KEY2));
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY3)))
+        .thenReturn(createArtifactSigner(PRIVATE_KEY3));
+
+    final Optional<ArtifactSigner> signer1 = signerProvider.getSigner(PUBLIC_KEY1);
+    assertThat(signerCache.size()).isEqualTo(1);
+    assertThat(signerCache.getIfPresent(PUBLIC_KEY1)).isSameAs(signer1.get());
+
+    final Optional<ArtifactSigner> signer2 = signerProvider.getSigner(PUBLIC_KEY2);
+    assertThat(signerCache.size()).isEqualTo(2);
+    assertThat(signerCache.getIfPresent(PUBLIC_KEY2)).isSameAs(signer2.get());
+
+    // first public key is evicted because size is limited to 2
+    final Optional<ArtifactSigner> signer3 = signerProvider.getSigner(PUBLIC_KEY3);
+    assertThat(signerCache.size()).isEqualTo(2);
+    assertThat(signerCache.asMap()).containsValues(signer2.get(), signer3.get());
+  }
+
+  @Test
+  void cacheAllSignersPopulatesCacheForAllIdentifiers() throws IOException {
+    createFileInConfigsDirectory(PUBLIC_KEY1);
+    createFileInConfigsDirectory(PUBLIC_KEY2);
+    createFileInConfigsDirectory(PUBLIC_KEY3);
+    final ArtifactSigner signer1 = createArtifactSigner(PRIVATE_KEY1);
+    final ArtifactSigner signer2 = createArtifactSigner(PRIVATE_KEY2);
+    final ArtifactSigner signer3 = createArtifactSigner(PRIVATE_KEY3);
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY1))).thenReturn(signer1);
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY2))).thenReturn(signer2);
+    when(signerParser.parse(pathEndsWith(PUBLIC_KEY3))).thenReturn(signer3);
+
+    assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
+
+    signerProvider.cacheAllSigners();
+    assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(3);
+    assertThat(signerProvider.getArtifactSignerCache().asMap())
+        .containsValues(signer1, signer2, signer3);
   }
 
   @Test

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.LoadingCache;
 import org.apache.logging.log4j.LogManager;

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.eth2signer.core.multikey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -190,39 +191,31 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void signerIdentifiersReturnedForMetadataFile() throws IOException {
-    createFileInConfigsDirectory(PUBLIC_KEY + ".yaml");
-    when(signerParser.parse(any())).thenReturn(artifactSigner);
+    createFileInConfigsDirectory(PUBLIC_KEY);
 
     assertThat(signerProvider.availableIdentifiers()).containsExactly("0x" + PUBLIC_KEY);
+    verify(signerParser, never()).parse(any());
   }
 
   @Test
   void signerIdentifiersReturnedForAllValidMetadataFilesInDirectory() throws IOException {
-    final String privateKey1 = "0x65d5d1dd92ed6b75ab662afdaeb4109948c05cffcdd299f62e58e3fb5edceb67";
     final String publicKey1 =
         "0x889477480fbcf2c7d32fafe50c60fc716545543a5660130e84041e6f6fce5fa471ef1e7c0cdd4380b83b8d33893e6f11";
     createFileInConfigsDirectory(publicKey1);
-    when(signerParser.parse(pathEndsWith(publicKey1)))
-        .thenReturn(createArtifactSigner(privateKey1));
 
-    final String privateKey2 = "0x430d79925d1bc810d2bd033178fdea98c59f29edd40e80cc7f13e92fcb05a86e";
     final String publicKey2 =
         "0xa7c5f1c815571d02df8ebc9b083e1a7fb4b360970cc40ebb325f3d2360dd1f9723825ea0c6fa9e398cd233ef0868a8cc";
     createFileInConfigsDirectory(publicKey2);
-    when(signerParser.parse(pathEndsWith(publicKey2)))
-        .thenReturn(createArtifactSigner(privateKey2));
 
-    final String privateKey3 = "0x62e4325a71315d5bb757458b560dc1957118c12466978c772c31bad86a7e3a5e";
     final String publicKey3 =
         "0xb458bf0b2e1d3797b2f95a0f80f715b18881f74d114c824f54452893fbe6368b32de3066e472dbeb1a43181416159606";
     createFileInConfigsDirectory(publicKey3);
-    when(signerParser.parse(pathEndsWith(publicKey3)))
-        .thenReturn(createArtifactSigner(privateKey3));
 
     final Collection<String> identifiers = signerProvider.availableIdentifiers();
 
     assertThat(identifiers).hasSize(3);
     assertThat(identifiers).containsOnly(publicKey1, publicKey2, publicKey3);
+    verify(signerParser, never()).parse(any());
   }
 
   @Test


### PR DESCRIPTION
Caches keys so that they don't need to be retrieved on every signing request.

* pre-loads all the keys into the cache on startup
* adds a new config option for the cache limit defaulting to 1000
* will cache signers if they are not already in the cache
* uses a LRU for evicting signers after reaching the size limit