### PR TITLE
Update teku and signer dependencies versions/package names.

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
@@ -16,7 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.eth2signer.dsl.utils.WaitUtils.waitFor;
 
-import tech.pegasys.artemis.util.bls.BLSPublicKey;
+import tech.pegasys.artemis.bls.BLSPublicKey;
 import tech.pegasys.eth2signer.core.http.SigningRequestBody;
 import tech.pegasys.eth2signer.dsl.HttpResponse;
 import tech.pegasys.eth2signer.dsl.signer.runner.Eth2SignerRunner;

--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -20,7 +20,9 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'org.hyperledger.besu:plugin-api'
   implementation 'org.hyperledger.besu.internal:metrics-core'
-  implementation 'org.yaml:snakeyaml'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  implementation 'commons-lang:commons-lang'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 

--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -73,7 +73,7 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
       throwParameterException(
           e, "Unable to read yaml configuration. File not found: " + configFile);
     } catch (final JsonMappingException e) {
-      throwParameterException(e, "Unexpected yaml content, expecting block mappings.");
+      throwParameterException(e, "Unexpected yaml content");
     } catch (final JsonParseException e) {
       throwParameterException(
           e,

--- a/commandline/src/test/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
@@ -104,7 +104,7 @@ class YamlConfigFileDefaultProviderTest {
     final String[] args = CmdlineHelpers.validBaseCommandOptions().split(" ");
     assertThatExceptionOfType(CommandLine.ParameterException.class)
         .isThrownBy(() -> commandLine.parseArgs(args))
-        .withMessage("Empty yaml configuration file: %s", configFile);
+        .withMessage("Unexpected yaml content, expecting block mappings.");
   }
 
   @Test

--- a/commandline/src/test/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/eth2signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
@@ -104,7 +104,7 @@ class YamlConfigFileDefaultProviderTest {
     final String[] args = CmdlineHelpers.validBaseCommandOptions().split(" ");
     assertThatExceptionOfType(CommandLine.ParameterException.class)
         .isThrownBy(() -> commandLine.parseArgs(args))
-        .withMessage("Unexpected yaml content, expecting block mappings.");
+        .withMessage("Unexpected yaml content");
   }
 
   @Test

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.http;
 
-import tech.pegasys.artemis.util.bls.BLSSignature;
+import tech.pegasys.artemis.bls.BLSSignature;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.utils.JsonDecoder;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -15,8 +15,8 @@ package tech.pegasys.eth2signer.core.multikey.metadata;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import tech.pegasys.artemis.util.bls.BLSKeyPair;
-import tech.pegasys.artemis.util.bls.BLSSecretKey;
+import tech.pegasys.artemis.bls.BLSKeyPair;
+import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.metrics.Eth2SignerMetricCategory;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.signers.bls.keystore.KeyStore;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.multikey.metadata;
 
-import tech.pegasys.artemis.util.bls.BLSSecretKey;
+import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
-import tech.pegasys.artemis.util.bls.BLSSecretKey;
+import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 
 import java.io.IOException;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
@@ -12,9 +12,9 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import tech.pegasys.artemis.util.bls.BLS;
-import tech.pegasys.artemis.util.bls.BLSKeyPair;
-import tech.pegasys.artemis.util.bls.BLSSignature;
+import tech.pegasys.artemis.bls.BLS;
+import tech.pegasys.artemis.bls.BLSKeyPair;
+import tech.pegasys.artemis.bls.BLSSignature;
 
 import org.apache.tuweni.bytes.Bytes;
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.artemis.util.bls.BLSKeyPair;
-import tech.pegasys.artemis.util.bls.BLSSecretKey;
+import tech.pegasys.artemis.bls.BLSKeyPair;
+import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.TrackingLogAppender;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -19,8 +19,8 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.artemis.util.bls.BLSKeyPair;
-import tech.pegasys.artemis.util.bls.BLSSecretKey;
+import tech.pegasys.artemis.bls.BLSKeyPair;
+import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileRawSigningMetadata;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,8 +16,6 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1'
 
-    dependency 'org.yaml:snakeyaml:1.26'
-
     dependency 'com.github.docker-java:docker-java:3.1.1'
 
     dependency 'com.google.errorprone:error_prone_annotation:2.3.4'
@@ -75,9 +73,9 @@ dependencyManagement {
     dependency 'org.hyperledger.besu.internal:metrics-core:1.4.0'
     dependency 'org.hyperledger.besu:plugin-api:1.4.0'
 
-    dependency 'tech.pegasys.signers.internal:bls-keystore:0.0.1-SNAPSHOT'
+    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
 
     dependency 'tech.pegasys.teku.internal:bls:0.8.2-SNAPSHOT'
-    dependency 'tech.pegasys.signers.internal:keystorage-hashicorp:0.0.1-SNAPSHOT'
+    dependency 'tech.pegasys.signers.internal:keystorage-hashicorp:1.0.0'
   }
 }


### PR DESCRIPTION
- Update teku and signer dependencies versions
- Fix BLS package names
- Update YamlConfigDefaultProvider to use Jackson YAMLFactory instead of directly using SnakeYaml

Signed-off-by: Usman Saleem <usman@usmans.info>