### PR TITLE
Add aggregate_and_proof endpoint

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -66,7 +66,8 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
         "/signer/block",
         "/signer/attestation",
         "/signer/randao_reveal",
-        "/signer/aggregation_slot"
+        "/signer/aggregation_slot",
+        "/signer/aggregate_and_proof"
       })
   public void signDataWithKeyLoadedFromUnencryptedFile(final String artifactSigningEndpoint)
       throws Exception {
@@ -155,7 +156,8 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
         "/signer/block",
         "/signer/attestation",
         "/signer/randao_reveal",
-        "/signer/aggregation_slot"
+        "/signer/aggregation_slot",
+        "/signer/aggregate_and_proof"
       })
   public void ableToSignUsingHashicorp(final String artifactSigningEndpoint)
       throws ExecutionException, InterruptedException {
@@ -193,9 +195,11 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
         Arguments.arguments("/signer/attestation", KdfFunction.SCRYPT),
         Arguments.arguments("/signer/randao_reveal", KdfFunction.SCRYPT),
         Arguments.arguments("/signer/aggregation_slot", KdfFunction.SCRYPT),
+        Arguments.arguments("/signer/aggregate_and_proof", KdfFunction.SCRYPT),
         Arguments.arguments("/signer/block", KdfFunction.PBKDF2),
         Arguments.arguments("/signer/attestation", KdfFunction.PBKDF2),
         Arguments.arguments("/signer/randao_reveal", KdfFunction.PBKDF2),
-        Arguments.arguments("/signer/aggregation_slot", KdfFunction.PBKDF2));
+        Arguments.arguments("/signer/aggregation_slot", KdfFunction.PBKDF2),
+        Arguments.arguments("/signer/aggregate_and_proof", KdfFunction.PBKDF2));
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/SigningRequestHandler.java
@@ -30,7 +30,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class SigningRequestHandler implements Handler<RoutingContext> {
 
   public static final String SIGNER_PATH_REGEX =
-      "/signer/(?<signerType>attestation|block|randao_reveal|aggregation_slot)/(?<publicKey>.*)";
+      "/signer/(?<signerType>attestation|block|randao_reveal|aggregation_slot|aggregate_and_proof)/(?<publicKey>.*)";
   private static final Logger LOG = LogManager.getLogger();
   private final ArtifactSignerProvider signerProvider;
   private final JsonDecoder jsonDecoder;


### PR DESCRIPTION
As of v0.11.1 of the beacon chain spec another object to be signed has been added SignedAggregateAndProof. This adds support for the SignedAggregateAndProof on the /signer/aggregate_and_proof endpoint. The behaviour is the same as all the other signing endpoints.

Fixes issue: https://github.com/PegaSysEng/eth2signer/issues/61