### PR TITLE
Load signing keys into cache in parallel

### DIFF
--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -28,8 +28,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ForkJoinTask;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -102,10 +100,11 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
         .collect(Collectors.toSet());
   }
 
-  public ForkJoinTask<?> cacheAllSigners() {
+  public void cacheAllSigners() {
     final Set<String> availableIdentifiers = availableIdentifiers();
-    return ForkJoinPool.commonPool()
-        .submit(() -> availableIdentifiers.parallelStream().forEach(this::cacheSigner));
+    LOG.info("Loading {} signers", availableIdentifiers.size());
+    availableIdentifiers.parallelStream().forEach(this::cacheSigner);
+    LOG.info("Loading signers complete");
   }
 
   private void cacheSigner(final String identifier) {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.Logger;
 public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProvider {
 
   private static final Logger LOG = LogManager.getLogger();
-  private static final int SIGNER_CACHING_PARALLELISM = 4;
   private final Path configsDirectory;
   private final String fileExtension;
   private final SignerParser signerParser;
@@ -105,9 +104,8 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
 
   public ForkJoinTask<?> cacheAllSigners() {
     final Set<String> availableIdentifiers = availableIdentifiers();
-    final ForkJoinPool artifactSignerThreadPool = new ForkJoinPool(SIGNER_CACHING_PARALLELISM);
-    return artifactSignerThreadPool.submit(
-        () -> availableIdentifiers.parallelStream().forEach(this::cacheSigner));
+    return ForkJoinPool.commonPool()
+        .submit(() -> availableIdentifiers.parallelStream().forEach(this::cacheSigner));
   }
 
   private void cacheSigner(final String identifier) {

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -366,7 +366,7 @@ class DirectoryBackedArtifactSignerProviderTest {
 
     assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
 
-    signerProvider.cacheAllSigners().get();
+    signerProvider.cacheAllSigners();
     assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(3);
     assertThat(signerProvider.getArtifactSignerCache().asMap())
         .containsKeys(PUBLIC_KEY1, PUBLIC_KEY2, PUBLIC_KEY3);

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -350,7 +350,7 @@ class DirectoryBackedArtifactSignerProviderTest {
 
   @Test
   void cacheAllSignersPopulatesCacheForAllIdentifiers()
-      throws IOException, ExecutionException, InterruptedException {
+      throws IOException {
     DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
             configsDirectory, FILE_EXTENSION, signerParser, 3);

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.LoadingCache;
 import org.apache.logging.log4j.LogManager;
@@ -349,8 +348,7 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   @Test
-  void cacheAllSignersPopulatesCacheForAllIdentifiers()
-      throws IOException {
+  void cacheAllSignersPopulatesCacheForAllIdentifiers() throws IOException {
     DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
             configsDirectory, FILE_EXTENSION, signerParser, 3);

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.LoadingCache;
 import org.apache.logging.log4j.LogManager;
@@ -348,7 +349,8 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   @Test
-  void cacheAllSignersPopulatesCacheForAllIdentifiers() throws IOException {
+  void cacheAllSignersPopulatesCacheForAllIdentifiers()
+      throws IOException, ExecutionException, InterruptedException {
     DirectoryBackedArtifactSignerProvider signerProvider =
         new DirectoryBackedArtifactSignerProvider(
             configsDirectory, FILE_EXTENSION, signerParser, 3);
@@ -364,8 +366,10 @@ class DirectoryBackedArtifactSignerProviderTest {
 
     assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(0);
 
-    signerProvider.cacheAllSigners();
+    signerProvider.cacheAllSigners().get();
     assertThat(signerProvider.getArtifactSignerCache().size()).isEqualTo(3);
+    assertThat(signerProvider.getArtifactSignerCache().asMap())
+        .containsKeys(PUBLIC_KEY1, PUBLIC_KEY2, PUBLIC_KEY3);
     assertThat(signerProvider.getArtifactSignerCache().asMap())
         .containsValues(signer1, signer2, signer3);
   }


### PR DESCRIPTION
Changes the load all signers logic to run in parallel to improve performance of loading the keys on startup.

https://github.com/PegaSysEng/eth2signer/issues/30