### PR TITLE
First draft secp256k1 signing

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
   implementation 'org.apache.tuweni:tuweni-bytes'
 
-  implementation 'tech.pegasys.signers.internal:keystorage-hashicorp'
+
 
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
@@ -38,6 +38,14 @@ dependencies {
   implementation 'tech.pegasys.signers.internal:bls-keystore'
 
   implementation 'tech.pegasys.teku.internal:bls'
+
+  implementation 'tech.pegasys.signers.internal:keystorage-hashicorp'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-api'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-azure'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-common'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-file-based'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-hashicorp'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-multikey'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/Secp256k1SigningHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/Secp256k1SigningHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.http;
+
+import tech.pegasys.eth2signer.core.utils.ByteUtils;
+import tech.pegasys.eth2signer.core.utils.JsonDecoder;
+import tech.pegasys.signers.secp256k1.api.Signature;
+import tech.pegasys.signers.secp256k1.api.TransactionSigner;
+import tech.pegasys.signers.secp256k1.multikey.MultiKeyTransactionSignerProvider;
+
+import java.util.Optional;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class Secp256k1SigningHandler implements Handler<RoutingContext> {
+
+  private static final Logger LOG = LogManager.getLogger();
+  public static final String SECP256k1_API_PATH = "/secp256k1/sign/(?<address>.*)";
+
+  final MultiKeyTransactionSignerProvider secp256k1Signer;
+  private final JsonDecoder jsonDecoder;
+
+  public Secp256k1SigningHandler(
+      final MultiKeyTransactionSignerProvider secp256k1Signer, final JsonDecoder jsonDecoder) {
+    this.secp256k1Signer = secp256k1Signer;
+    this.jsonDecoder = jsonDecoder;
+  }
+
+  @Override
+  public void handle(final RoutingContext context) {
+    LOG.debug("Received a request for {}", context.normalisedPath());
+    final String address = getAddress(context);
+    final Optional<TransactionSigner> signer = secp256k1Signer.getSigner(address);
+    if (signer.isEmpty()) {
+      LOG.error("Unable to find an appropriate signer for request: {}", address);
+      context.fail(404);
+    } else {
+      final Bytes dataToSign = getDataToSign(context);
+      final Signature signature = signer.get().sign(dataToSign.toArrayUnsafe());
+
+      // Copied from EthSigner (EthSignBodyProvider
+      final Bytes outputSignature =
+          Bytes.concatenate(
+              Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signature.getR()))),
+              Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signature.getS()))),
+              Bytes.wrap(ByteUtils.bigIntegerToBytes(signature.getV())));
+
+      context.response().end(outputSignature.toString());
+    }
+  }
+
+  private String getAddress(final RoutingContext context) {
+    return context.pathParam("address");
+  }
+
+  private Bytes getDataToSign(final RoutingContext context) {
+    final Buffer body = context.getBody();
+    final SigningRequestBody signingRequest =
+        jsonDecoder.decodeValue(body, SigningRequestBody.class);
+    return signingRequest.signingRoot();
+  }
+}

--- a/core/src/main/java/tech/pegasys/eth2signer/core/utils/ByteUtils.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/utils/ByteUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.utils;
+
+import java.math.BigInteger;
+
+public class ByteUtils {
+
+  /**
+   * Omitting sign indication byte. <br>
+   * <br>
+   * Instead of {@link org.bouncycastle.util.BigIntegers#asUnsignedByteArray(BigInteger)} <br>
+   * we use this custom method to avoid an empty array in case of BigInteger.ZERO
+   *
+   * @param value - any big integer number. A <code>null</code>-value will return <code>null</code>
+   * @return A byte array without a leading zero byte if present in the signed encoding.
+   *     BigInteger.ZERO will return an array with length 1 and byte-value 0.
+   */
+  public static byte[] bigIntegerToBytes(final BigInteger value) {
+    if (value == null) {
+      return null;
+    }
+
+    byte[] data = value.toByteArray();
+
+    if (data.length != 1 && data[0] == 0) {
+      byte[] tmp = new byte[data.length - 1];
+      System.arraycopy(data, 1, tmp, 0, tmp.length);
+      data = tmp;
+    }
+    return data;
+  }
+}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -77,5 +77,14 @@ dependencyManagement {
 
     dependency 'tech.pegasys.teku.internal:bls:0.8.2-SNAPSHOT'
     dependency 'tech.pegasys.signers.internal:keystorage-hashicorp:1.0.0'
+
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2-SNAPSHOT') {
+      entry 'signing-secp256k1-api'
+      entry 'signing-secp256k1-azure'
+      entry 'signing-secp256k1-common'
+      entry 'signing-secp256k1-file-based'
+      entry 'signing-secp256k1-hashicorp'
+      entry 'signing-secp256k1-multikey'
+    }
   }
 }


### PR DESCRIPTION
This creates a dependency on the signers repo, and offers secp256k1 signing on the /secp256k1/sign/<address> path.

It loads key "definition" files in toml format from the config directory specified on the cli.