### PR TITLE
added helm chart

### DIFF
--- a/helm/eth2signer/.helmignore
+++ b/helm/eth2signer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/eth2signer/Chart.yaml
+++ b/helm/eth2signer/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: eth2signer
+description: etth2signer Helm chart for Kubernetes
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1

--- a/helm/eth2signer/templates/_helpers.tpl
+++ b/helm/eth2signer/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eth2signer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eth2signer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eth2signer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eth2signer.labels" -}}
+helm.sh/chart: {{ include "eth2signer.chart" . }}
+{{ include "eth2signer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eth2signer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eth2signer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eth2signer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "eth2signer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/eth2signer/templates/configmap.tpl
+++ b/helm/eth2signer/templates/configmap.tpl
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "eth2signer.name" . }}
+    chart: {{ template "eth2signer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+
+data:
+{{ toYaml .Values.config | indent 2 }}
+
+
+

--- a/helm/eth2signer/templates/service.yaml
+++ b/helm/eth2signer/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service.enabled }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "eth2signer.name" . }}
+    chart: {{ template "eth2signer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: {{ .Values.service.metricsPort }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ template "eth2signer.name" . }}
+    release: {{ .Release.Name }}
+
+{{- end}}

--- a/helm/eth2signer/templates/service.yaml
+++ b/helm/eth2signer/templates/service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.service.enabled }}
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,8 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: ClusterIP
-  clusterIP: None
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
@@ -24,5 +25,4 @@ spec:
   selector:
     app: {{ template "eth2signer.name" . }}
     release: {{ .Release.Name }}
-
 {{- end}}

--- a/helm/eth2signer/templates/servicemonitor.yaml
+++ b/helm/eth2signer/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.service.metrics .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "eth2signer.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "eth2signer.name" . }}
+    chart: {{ template "eth2signer.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+  {{- if .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+{{ toYaml .Values.serviceMonitor.namespaceSelector | indent 4 -}}
+  {{ else }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "eth2signer.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/helm/eth2signer/templates/statefulset.yaml
+++ b/helm/eth2signer/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "eth2signer.fullname" . }}

--- a/helm/eth2signer/templates/statefulset.yaml
+++ b/helm/eth2signer/templates/statefulset.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ template "eth2signer.fullname" . }}
+  labels:
+    app: {{ template "eth2signer.name" . }}
+    chart: {{ template "eth2signer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "eth2signer.name" . }}
+      release: {{ .Release.Name }}
+
+  {{- with .Values.updateStrategy}}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
+
+  serviceName: {{ .Release.Name }}
+  podManagementPolicy: {{.Values.podManagementPolicy |  default "Parallel" }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "eth2signer.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        configHash: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum  }}
+    spec:
+      {{- with .Values.securityContext}}
+      securityContext:
+        {{- toYaml . | nindent 10 }}
+      {{- end}}
+
+      containers:
+      - name: eth2signer
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.command}}
+        command:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
+        args:
+          - --http-listen-port={{ .Values.service.port }}
+          - --http-listen-host=0.0.0.0
+          - --key-store-path=/data
+          - --logging=ALL
+          {{- if .Values.service.metrics }}
+          - --metrics-enabled
+          - --metrics-port={{ .Values.service.metricsPort }}
+          - --metrics-host=0.0.0.0
+          {{- end }}
+        {{- with .Values.args }}
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
+        {{- with .Values.env}}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
+        ports:
+        - containerPort: {{ .Values.service.port }}
+          name: http
+        - containerPort: {{ .Values.service.metricsPort }}
+          name: metrics
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
+        {{- with .Values.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: {{ template "eth2signer.fullname" . }}
+          mountPath: /data
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 11 }}
+
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "eth2signer.fullname" . }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .Values.persistence.storageClassName | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.diskSize | quote }}

--- a/helm/eth2signer/values.yaml
+++ b/helm/eth2signer/values.yaml
@@ -14,6 +14,7 @@ args: []
 service:
   enabled: true
   type: ClusterIP
+  # clusterIP: None
   port: 9000
   metrics: false
   metricsPort: 9001
@@ -36,4 +37,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-

--- a/helm/eth2signer/values.yaml
+++ b/helm/eth2signer/values.yaml
@@ -1,0 +1,39 @@
+image:
+  repository: pegasyseng/eth2signer
+  tag: develop
+  pullPolicy: Always
+
+replicaCount: 1
+
+persistence:
+  diskSize: "50Mi"
+
+# Additional eth2signer command line arguments
+args: []
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 9000
+  metrics: false
+  metricsPort: 9001
+
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+  namespaceSelector: {}
+  # Default: scrape .Release.Namespace only
+  # To scrape all, use the following:
+  # namespaceSelector:
+  #   any: true
+  scrapeInterval: 15s
+  # honorLabels: true
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+


### PR DESCRIPTION
because this is a stateful set with a  persistent volume it's most useful for deployments with local storage. it should probably have a stateless version as well, for when it's set to connect to hashicorp vault