### PR TITLE
Metrics allow hostlist

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/Signer.java
@@ -68,6 +68,10 @@ public class Signer {
   }
 
   public String getUrl() {
-    return String.format(urlFormatting, hostname, runner.httpJsonRpcPort());
+    return String.format(urlFormatting, hostname, runner.httpPort());
+  }
+
+  public String getMetricsUrl() {
+    return String.format(urlFormatting, hostname, runner.metricsPort());
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfiguration.java
@@ -13,6 +13,7 @@
 package tech.pegasys.eth2signer.dsl.signer;
 
 import java.nio.file.Path;
+import java.util.List;
 
 public class SignerConfiguration {
 
@@ -21,12 +22,23 @@ public class SignerConfiguration {
   private final String hostname;
   private final int httpRpcPort;
   private final Path keyStorePath;
+  private final List<String> metricsHostAllowList;
+  private final boolean metricsEnabled;
+  private final int metricsPort;
 
   public SignerConfiguration(
-      final String hostname, final int httpRpcPort, final Path keyStorePath) {
+      final String hostname,
+      final int httpRpcPort,
+      final Path keyStorePath,
+      final int metricsPort,
+      final List<String> metricsHostAllowList,
+      final boolean metricsEnabled) {
     this.hostname = hostname;
     this.httpRpcPort = httpRpcPort;
     this.keyStorePath = keyStorePath;
+    this.metricsPort = metricsPort;
+    this.metricsHostAllowList = metricsHostAllowList;
+    this.metricsEnabled = metricsEnabled;
   }
 
   public String hostname() {
@@ -41,7 +53,23 @@ public class SignerConfiguration {
     return keyStorePath;
   }
 
-  public boolean isDynamicPortAllocation() {
+  public boolean isHttpDynamicPortAllocation() {
     return httpRpcPort == UNASSIGNED_PORT;
+  }
+
+  public boolean isMetricsEnabled() {
+    return metricsEnabled;
+  }
+
+  public int getMetricsPort() {
+    return metricsPort;
+  }
+
+  public boolean isMetricsDynamicPortAllocation() {
+    return metricsPort == UNASSIGNED_PORT;
+  }
+
+  public List<String> getMetricsHostAllowList() {
+    return metricsHostAllowList;
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfigurationBuilder.java
@@ -13,13 +13,17 @@
 package tech.pegasys.eth2signer.dsl.signer;
 
 import java.nio.file.Path;
+import java.util.List;
 
 public class SignerConfigurationBuilder {
 
   private static final String LOCALHOST = "127.0.0.1";
 
   private int httpRpcPort = 0;
+  private int metricsPort = 0;
   private Path keyStoreDirectory = Path.of("./");
+  private boolean metricsEnabled;
+  private List<String> metricsAllowHostList;
 
   public SignerConfigurationBuilder withHttpPort(final int port) {
     httpRpcPort = port;
@@ -31,7 +35,28 @@ public class SignerConfigurationBuilder {
     return this;
   }
 
+  public SignerConfigurationBuilder withMetricsPort(final int port) {
+    metricsPort = port;
+    return this;
+  }
+
+  public SignerConfigurationBuilder withMetricsAllowHostList(final List<String> allowHostList) {
+    this.metricsAllowHostList = allowHostList;
+    return this;
+  }
+
+  public SignerConfigurationBuilder withMetricsEnabled(final boolean metricsEnabled) {
+    this.metricsEnabled = metricsEnabled;
+    return this;
+  }
+
   public SignerConfiguration build() {
-    return new SignerConfiguration(LOCALHOST, httpRpcPort, keyStoreDirectory);
+    return new SignerConfiguration(
+        LOCALHOST,
+        httpRpcPort,
+        keyStoreDirectory,
+        metricsPort,
+        metricsAllowHostList,
+        metricsEnabled);
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/SignerConfigurationBuilder.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.eth2signer.dsl.signer;
 
+import static java.util.Collections.emptyList;
+
 import java.nio.file.Path;
 import java.util.List;
 
@@ -23,7 +25,7 @@ public class SignerConfigurationBuilder {
   private int metricsPort = 0;
   private Path keyStoreDirectory = Path.of("./");
   private boolean metricsEnabled;
-  private List<String> metricsAllowHostList;
+  private List<String> metricsAllowHostList = emptyList();
 
   public SignerConfigurationBuilder withHttpPort(final int port) {
     httpRpcPort = port;

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerRunner.java
@@ -43,6 +43,7 @@ public abstract class Eth2SignerRunner {
 
   private static final String PORTS_FILENAME = "eth2signer.ports";
   private static final String HTTP_PORT_KEY = "http-port";
+  private static final String METRICS_PORT_KEY = "metrics-port";
 
   public static Eth2SignerRunner createRunner(final SignerConfiguration signerConfig) {
     if (Boolean.getBoolean("acctests.runEth2SignerAsProcess")) {
@@ -58,7 +59,7 @@ public abstract class Eth2SignerRunner {
     this.signerConfig = signerConfig;
     this.portsProperties = new Properties();
 
-    if (signerConfig.isDynamicPortAllocation()) {
+    if (signerConfig.isHttpDynamicPortAllocation()) {
       try {
         this.dataPath = Files.createTempDirectory("acceptance-test");
       } catch (final IOException e) {
@@ -75,7 +76,7 @@ public abstract class Eth2SignerRunner {
 
     startExecutor(params);
 
-    if (signerConfig.isDynamicPortAllocation()) {
+    if (signerConfig.isHttpDynamicPortAllocation()) {
       loadPortsFile();
     }
   }
@@ -86,7 +87,7 @@ public abstract class Eth2SignerRunner {
     try {
       shutdownExecutor();
     } finally {
-      if (signerConfig.isDynamicPortAllocation()) {
+      if (signerConfig.isHttpDynamicPortAllocation()) {
         try {
           MoreFiles.deleteRecursively(dataPath, RecursiveDeleteOption.ALLOW_INSECURE);
         } catch (final IOException e) {
@@ -112,7 +113,17 @@ public abstract class Eth2SignerRunner {
     params.add(String.valueOf(signerConfig.httpPort()));
     params.add("--key-store-path");
     params.add(signerConfig.getKeyStorePath().toString());
-    if (signerConfig.isDynamicPortAllocation()) {
+    if (signerConfig.isMetricsEnabled()) {
+      params.add("--metrics-enabled");
+      params.add("--metrics-port");
+      params.add(Integer.toString(signerConfig.getMetricsPort()));
+      if (signerConfig.getMetricsHostAllowList() != null) {
+        params.add("--metrics-host-allowlist");
+        final String allowList = String.join(",", signerConfig.getMetricsHostAllowList());
+        params.add(allowList);
+      }
+    }
+    if (signerConfig.isHttpDynamicPortAllocation()) {
       params.add("--data-path");
       params.add(dataPath.toAbsolutePath().toString());
     }
@@ -149,14 +160,25 @@ public abstract class Eth2SignerRunner {
             });
   }
 
-  public int httpJsonRpcPort() {
-    if (signerConfig.isDynamicPortAllocation()) {
+  public int httpPort() {
+    if (signerConfig.isHttpDynamicPortAllocation()) {
       final String value = portsProperties.getProperty(HTTP_PORT_KEY);
       LOG.info("{}: {}", HTTP_PORT_KEY, value);
       assertThat(value).isNotEmpty();
       return Integer.parseInt(value);
     } else {
       return signerConfig.httpPort();
+    }
+  }
+
+  public int metricsPort() {
+    if (signerConfig.isMetricsDynamicPortAllocation()) {
+      final String value = portsProperties.getProperty(METRICS_PORT_KEY);
+      LOG.info("{}: {}", METRICS_PORT_KEY, value);
+      assertThat(value).isNotEmpty();
+      return Integer.parseInt(value);
+    } else {
+      return signerConfig.getMetricsPort();
     }
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerRunner.java
@@ -117,7 +117,7 @@ public abstract class Eth2SignerRunner {
       params.add("--metrics-enabled");
       params.add("--metrics-port");
       params.add(Integer.toString(signerConfig.getMetricsPort()));
-      if (signerConfig.getMetricsHostAllowList() != null) {
+      if (!signerConfig.getMetricsHostAllowList().isEmpty()) {
         params.add("--metrics-host-allowlist");
         final String allowList = String.join(",", signerConfig.getMetricsHostAllowList());
         params.add(allowList);

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/MetricsAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/MetricsAcceptanceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.tests;
+
+import static io.restassured.RestAssured.given;
+
+import tech.pegasys.eth2signer.dsl.signer.SignerConfiguration;
+import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
+
+import java.util.Collections;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+public class MetricsAcceptanceTest extends AcceptanceTestBase {
+
+  private static final String METRICS_ENDPOINT = "/metrics";
+
+  @Test
+  void metricsWithDefaultAllowHostsRespondsWithOkResponse() {
+    final SignerConfiguration signerConfiguration =
+        new SignerConfigurationBuilder().withMetricsEnabled(true).build();
+    startSigner(signerConfiguration);
+
+    given()
+        .baseUri(signer.getMetricsUrl())
+        .contentType(ContentType.JSON)
+        .when()
+        .get(METRICS_ENDPOINT)
+        .then()
+        .assertThat()
+        .statusCode(200);
+  }
+
+  @Test
+  void metricsForAllowedHostRespondsWithOkResponse() {
+    final SignerConfiguration signerConfiguration =
+        new SignerConfigurationBuilder()
+            .withMetricsAllowHostList(Collections.singletonList("foo"))
+            .withMetricsEnabled(true)
+            .build();
+    startSigner(signerConfiguration);
+
+    given()
+        .baseUri(signer.getMetricsUrl())
+        .contentType(ContentType.JSON)
+        .when()
+        .header("host", "foo")
+        .get(METRICS_ENDPOINT)
+        .then()
+        .assertThat()
+        .statusCode(200);
+  }
+
+  @Test
+  void metricsForNonAllowedHostRespondsWithForbiddenResponse() {
+    final SignerConfiguration signerConfiguration =
+        new SignerConfigurationBuilder()
+            .withMetricsAllowHostList(Collections.singletonList("foo"))
+            .withMetricsEnabled(true)
+            .build();
+    startSigner(signerConfiguration);
+
+    given()
+        .baseUri(signer.getMetricsUrl())
+        .contentType(ContentType.JSON)
+        .when()
+        .header("host", "bar")
+        .get(METRICS_ENDPOINT)
+        .then()
+        .assertThat()
+        .statusCode(403);
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/AllowListHostsProperty.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/AllowListHostsProperty.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.commandline;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+public class AllowListHostsProperty extends AbstractList<String> {
+
+  private final List<String> hostnamesAllowlist = new ArrayList<>();
+
+  public AllowListHostsProperty() {}
+
+  @Override
+  @Nonnull
+  public Iterator<String> iterator() {
+    if (hostnamesAllowlist.size() == 1 && hostnamesAllowlist.get(0).equals("none")) {
+      return Collections.emptyIterator();
+    } else {
+      return hostnamesAllowlist.iterator();
+    }
+  }
+
+  @Override
+  public int size() {
+    return hostnamesAllowlist.size();
+  }
+
+  @Override
+  public boolean add(final String string) {
+    return addAll(Collections.singleton(string));
+  }
+
+  @Override
+  public String get(final int index) {
+    return hostnamesAllowlist.get(index);
+  }
+
+  @Override
+  public boolean addAll(final Collection<? extends String> collection) {
+    final int initialSize = hostnamesAllowlist.size();
+    for (final String string : collection) {
+      if (Strings.isNullOrEmpty(string)) {
+        throw new IllegalArgumentException("Hostname cannot be empty string or null string.");
+      }
+      for (final String s : Splitter.onPattern("\\s*,+\\s*").split(string)) {
+        if ("all".equals(s)) {
+          hostnamesAllowlist.add("*");
+        } else {
+          hostnamesAllowlist.add(s);
+        }
+      }
+    }
+
+    if (hostnamesAllowlist.contains("none")) {
+      if (hostnamesAllowlist.size() > 1) {
+        throw new IllegalArgumentException("Value 'none' can't be used with other hostnames");
+      }
+    } else if (hostnamesAllowlist.contains("*")) {
+      if (hostnamesAllowlist.size() > 1) {
+        throw new IllegalArgumentException(
+            "Values '*' or 'all' can't be used with other hostnames");
+      }
+    }
+
+    return hostnamesAllowlist.size() != initialSize;
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
@@ -209,11 +209,18 @@ public class Eth2SignerCommand implements Config, Runnable {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .add("configFile", configFile)
+        .add("dataPath", dataPath)
+        .add("keyStorePath", keyStorePath)
+        .add("keyCacheLimit", keyCacheLimit)
         .add("logLevel", logLevel)
         .add("httpListenHost", httpListenHost)
         .add("httpListenPort", httpListenPort)
-        .add("dataPath", dataPath)
-        .add("keystorePath", keyStorePath)
+        .add("metricsEnabled", metricsEnabled)
+        .add("metricsHost", metricsHost)
+        .add("metricsPort", metricsPort)
+        .add("metricCategories", metricCategories)
+        .add("metricsHostAllowList", metricsHostAllowList)
         .toString();
   }
 

--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
@@ -26,6 +26,7 @@ import tech.pegasys.eth2signer.core.metrics.Eth2SignerMetricCategory;
 import java.io.File;
 import java.net.InetAddress;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
@@ -142,6 +143,14 @@ public class Eth2SignerCommand implements Config, Runnable {
       converter = Eth2SignerMetricCategoryConverter.class)
   private final Set<MetricCategory> metricCategories = DEFAULT_METRIC_CATEGORIES;
 
+  @Option(
+      names = {"--metrics-host-allowlist"},
+      paramLabel = "<hostname>[,<hostname>...]... or * or all",
+      description =
+          "Comma separated list of hostnames to allow for metrics access, or * to accept any host (default: ${DEFAULT-VALUE})",
+      defaultValue = "localhost,127.0.0.1")
+  private final AllowListHostsProperty metricsHostAllowList = new AllowListHostsProperty();
+
   @Override
   public Level getLogLevel() {
     return logLevel;
@@ -185,6 +194,11 @@ public class Eth2SignerCommand implements Config, Runnable {
   @Override
   public Set<MetricCategory> getMetricCategories() {
     return metricCategories;
+  }
+
+  @Override
+  public List<String> getMetricsHostAllowList() {
+    return metricsHostAllowList;
   }
 
   @Override

--- a/commandline/src/test/java/tech/pegasys/eth2signer/commandline/AllowListHostsPropertyTest.java
+++ b/commandline/src/test/java/tech/pegasys/eth2signer/commandline/AllowListHostsPropertyTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.commandline;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AllowListHostsPropertyTest {
+  final AllowListHostsProperty allowListHostsProperty = new AllowListHostsProperty();
+
+  @Test
+  void cannotContainEmptyString() {
+    assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList("")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Hostname cannot be empty string or null string.");
+  }
+
+  @Test
+  void cannotContainNullString() {
+    assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Hostname cannot be empty string or null string.");
+  }
+
+  @Test
+  void allCannotBeCombinedWithOtherHostnames() {
+    assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList("all, foo")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Values '*' or 'all' can't be used with other hostnames");
+  }
+
+  @Test
+  void WildcardCannotBeCombinedWithOtherHostnames() {
+    assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList("*, foo")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Values '*' or 'all' can't be used with other hostnames");
+  }
+
+  @Test
+  void noneCannotBeCombinedWithOtherHostnames() {
+    assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList("none, foo")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Value 'none' can't be used with other hostnames");
+  }
+
+  @Test
+  void hostnamesArePopulatedFromCommaSeparatedValues() {
+    final boolean modified = allowListHostsProperty.addAll(singletonList("foo, bar, nothing"));
+    assertThat(modified).isTrue();
+    assertThat(allowListHostsProperty).contains("foo", "bar", "nothing");
+  }
+
+  @Test
+  void nonePopulatesEmptyList() {
+    allowListHostsProperty.addAll(singletonList("none"));
+    assertThat(allowListHostsProperty).isEmpty();
+  }
+
+  @Test
+  void allPopulatesAsWildcard() {
+    final boolean modified = allowListHostsProperty.addAll(singletonList("all"));
+    assertThat(modified).isTrue();
+    assertThat(allowListHostsProperty).contains("*");
+  }
+}

--- a/commandline/src/test/java/tech/pegasys/eth2signer/commandline/AllowListHostsPropertyTest.java
+++ b/commandline/src/test/java/tech/pegasys/eth2signer/commandline/AllowListHostsPropertyTest.java
@@ -43,7 +43,7 @@ class AllowListHostsPropertyTest {
   }
 
   @Test
-  void WildcardCannotBeCombinedWithOtherHostnames() {
+  void wildcardCannotBeCombinedWithOtherHostnames() {
     assertThatThrownBy(() -> allowListHostsProperty.addAll(singletonList("*, foo")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Values '*' or 'all' can't be used with other hostnames");

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Config.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Config.java
@@ -13,6 +13,7 @@
 package tech.pegasys.eth2signer.core;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Level;
@@ -37,6 +38,8 @@ public interface Config {
   String getMetricsNetworkInterface();
 
   Set<MetricCategory> getMetricCategories();
+
+  List<String> getMetricsHostAllowList();
 
   Long getKeyCacheLimit();
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -119,7 +120,7 @@ public class Runner implements Runnable {
       final HttpServer httpServer = createServerAndWait(vertx, router);
       LOG.info("Server is up, and listening on {}", httpServer.actualPort());
 
-      persistPortInformation(httpServer.actualPort());
+      persistPortInformation(httpServer.actualPort(), metricsEndpoint.getPort());
     } catch (final Throwable e) {
       vertx.close();
       metricsEndpoint.stop();
@@ -219,7 +220,7 @@ public class Runner implements Runnable {
     return httpServer;
   }
 
-  private void persistPortInformation(final int listeningPort) {
+  private void persistPortInformation(final int httpPort, final Optional<Integer> metricsPort) {
     if (config.getDataPath() == null) {
       return;
     }
@@ -228,7 +229,8 @@ public class Runner implements Runnable {
     portsFile.deleteOnExit();
 
     final Properties properties = new Properties();
-    properties.setProperty("http-port", String.valueOf(listeningPort));
+    properties.setProperty("http-port", String.valueOf(httpPort));
+    metricsPort.ifPresent(port -> properties.setProperty("metrics-port", String.valueOf(port)));
 
     LOG.info(
         "Writing eth2signer.ports file: {}, with contents: {}",

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -82,7 +82,8 @@ public class Runner implements Runnable {
             config.isMetricsEnabled(),
             config.getMetricsPort(),
             config.getMetricsNetworkInterface(),
-            config.getMetricCategories());
+            config.getMetricCategories(),
+            config.getMetricsHostAllowList());
 
     final MetricsSystem metricsSystem = metricsEndpoint.getMetricsSystem();
     final MetricsOptions metricsOptions =

--- a/core/src/main/java/tech/pegasys/eth2signer/core/metrics/MetricsEndpoint.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/metrics/MetricsEndpoint.java
@@ -58,6 +58,10 @@ public class MetricsEndpoint {
     metricsService.ifPresent(MetricsService::stop);
   }
 
+  public Optional<Integer> getPort() {
+    return metricsService.flatMap(MetricsService::getPort);
+  }
+
   public MetricsSystem getMetricsSystem() {
     return metricsSystem;
   }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/metrics/MetricsEndpoint.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/metrics/MetricsEndpoint.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.metrics;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -31,10 +32,15 @@ public class MetricsEndpoint {
       final Boolean metricsEnabled,
       final Integer metricsPort,
       final String metricsNetworkInterface,
-      final Set<MetricCategory> metricCategories) {
+      final Set<MetricCategory> metricCategories,
+      final List<String> metricsHostAllowList) {
     final MetricsConfiguration metricsConfig =
         createMetricsConfiguration(
-            metricsEnabled, metricsPort, metricsNetworkInterface, metricCategories);
+            metricsEnabled,
+            metricsPort,
+            metricsNetworkInterface,
+            metricCategories,
+            metricsHostAllowList);
     this.metricsSystem = PrometheusMetricsSystem.init(metricsConfig);
     this.metricsConfig = metricsConfig;
   }
@@ -60,12 +66,14 @@ public class MetricsEndpoint {
       final Boolean metricsEnabled,
       final Integer metricsPort,
       final String metricsNetworkInterface,
-      final Set<MetricCategory> metricCategories) {
+      final Set<MetricCategory> metricCategories,
+      final List<String> metricsHostAllowList) {
     return MetricsConfiguration.builder()
         .enabled(metricsEnabled)
         .port(metricsPort)
         .host(metricsNetworkInterface)
         .metricCategories(metricCategories)
+        .hostsWhitelist(metricsHostAllowList)
         .build();
   }
 }


### PR DESCRIPTION
Adds a new command line option --metrics-host-allowlist to allow configuration of the metrics allow host list. The metrics endpoint always supported the allow host list functionality but it wasn't possible to configure this. The metrics allow host list functionality restricts access to the list hostnames.

fixes #97 