### PR TITLE
Add metricsHostAllowList to helm chart

### DIFF
--- a/helm/eth2signer/templates/statefulset.yaml
+++ b/helm/eth2signer/templates/statefulset.yaml
@@ -51,6 +51,7 @@ spec:
           - --metrics-enabled
           - --metrics-port={{ .Values.service.metricsPort }}
           - --metrics-host=0.0.0.0
+          - --metrics-host-allowlist={{ .Values.service.metricsHostAllowList }}
           {{- end }}
         {{- with .Values.args }}
           {{- toYaml . | nindent 10 }}

--- a/helm/eth2signer/values.yaml
+++ b/helm/eth2signer/values.yaml
@@ -18,6 +18,7 @@ service:
   port: 9000
   metrics: false
   metricsPort: 9001
+  metricsHostAllowList: "localhost, 127.0.0.1"
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Adds the --metricsHostAllowList as a configurable value to the Helm chart so the the host list can be easily configured when used in Kubernetes.

#97 