### PR TITLE
Change swagger endpoint from /openapi to /swagger-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Eth2Signer issues are tracked in GitHub.
 
 See our [contribution guidelines](CONTRIBUTING.md) for more detail on searching and creating issues.
 
-## Specs
-* [OpenAPI Specs](core/src/resources/openapi/eth2signer.yaml)
+## API
+* [API Documentation](https://pegasyseng.github.io/eth2signer/)
 
 ## Users
 * [User documentation](https://docs.eth2signer.pegasys.tech/)

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/AcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/AcceptanceTestBase.java
@@ -28,7 +28,7 @@ public class AcceptanceTestBase {
   }
 
   protected OpenApiValidationFilter getOpenApiValidationFilter() {
-    final String swaggerUrl = signer.getUrl() + "/openapi/eth2signer.yaml";
+    final String swaggerUrl = signer.getUrl() + "/swagger-ui/eth2signer.yaml";
     return new OpenApiValidationFilter(swaggerUrl);
   }
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -65,6 +65,7 @@ public class Runner implements Runnable {
   private static final String UPCHECK_OPERATION_ID = "upcheck";
   private static final String GET_PUBLIC_KEYS_OPERATION_ID = "getPublicKeys";
   private static final String SIGN_FOR_PUBLIC_KEY_OPERATION_ID = "signForPublicKey";
+  private static final String SWAGGER_ENDPOINT = "/swagger-ui";
 
   private final Config config;
 
@@ -180,13 +181,13 @@ public class Runner implements Runnable {
     final String openApiSpecYaml = Resources.toString(openApiSpecUrl, Charsets.UTF_8);
 
     router
-        .route(HttpMethod.GET, "/openapi/eth2signer.yaml")
+        .route(HttpMethod.GET, SWAGGER_ENDPOINT + "/eth2signer.yaml")
         .produces(CONTENT_TYPE_YAML)
         .handler(ResponseContentTypeHandler.create())
         .handler(routingContext -> routingContext.response().end(openApiSpecYaml));
 
     router
-        .route(HttpMethod.GET, "/openapi/*")
+        .route(HttpMethod.GET, SWAGGER_ENDPOINT + "/*")
         .produces(CONTENT_TYPE_TEXT_HTML)
         .handler(ResponseContentTypeHandler.create())
         .handler(routingContext -> routingContext.response().end(indexHtml));


### PR DESCRIPTION
The swagger ui can be accessed from `http://localhost:9000/swagger-ui` while eth2signer is running.

Fixes issue #108 

Signed-off-by: Usman Saleem <usman@usmans.info>