### PR TITLE
Fix TLS allow hostlist not working at runtime due to missing bouncycastle lib

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -46,7 +46,6 @@ task acceptanceTest(type: Test) {
   description = 'Runs Eth2Signer acceptance tests.'
   group = 'verification'
 
-  setSystemProperties(test.getSystemProperties())
   systemProperty 'acctests.runEth2SignerAsProcess', 'true'
 
   useJUnitPlatform()

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   testRuntimeOnly 'javax.activation:activation'
   testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-  testRuntimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   testImplementation 'com.github.docker-java:docker-java'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testRuntimeOnly 'javax.activation:activation'
   testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testRuntimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   testImplementation 'com.github.docker-java:docker-java'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
@@ -44,6 +45,9 @@ task acceptanceTest(type: Test) {
   mustRunAfter rootProject.subprojects*.test
   description = 'Runs Eth2Signer acceptance tests.'
   group = 'verification'
+
+  setSystemProperties(test.getSystemProperties())
+  systemProperty 'acctests.runEth2SignerAsProcess', 'true'
 
   useJUnitPlatform()
   // toggle to show standard out and standard error of the test JVM(s) on the console

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerProcessRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/signer/runner/Eth2SignerProcessRunner.java
@@ -65,15 +65,9 @@ public class Eth2SignerProcessRunner extends Eth2SignerRunner {
     if (Boolean.getBoolean("debugSubProcess")) {
       javaOpts.add("-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
     }
-    processBuilder.environment().put("JAVA_OPTS", javaOpts.toString());
 
-    if (Boolean.getBoolean("debugSubProcess")) {
-      javaOpts.add("-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
-    }
+    javaOpts.add(createTrustStoreOptions());
     processBuilder.environment().put("JAVA_OPTS", javaOpts.toString());
-
-    final String trustStoreOptions = createTrustStoreOptions();
-    javaOpts.add(trustStoreOptions);
 
     try {
       process = processBuilder.start();

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-junit-jupiter'
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  runtimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,13 +43,13 @@ dependencies {
   implementation 'tech.pegasys.teku.internal:bls'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-  runtimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
Fix TLS allow hostlist not working at runtime

* Added missing bouncycastle library as runtime dependency
* Changed gradle build so that the process runner is used when run as part of the build
* Fixed java opts not being set correctly in the process runner