### PR TITLE
Update to latest BLS version

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/utils/MetadataFileHelpers.java
@@ -15,7 +15,6 @@ package tech.pegasys.eth2signer.dsl.utils;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction.HMAC_SHA256;
 
-import tech.pegasys.artemis.bls.BLSKeyPair;
 import tech.pegasys.eth2signer.dsl.HashicorpSigningParams;
 import tech.pegasys.signers.bls.keystore.KeyStore;
 import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
@@ -27,6 +26,7 @@ import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
 import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 import tech.pegasys.signers.hashicorp.dsl.certificates.CertificateHelpers;
+import tech.pegasys.teku.bls.BLSKeyPair;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -17,17 +17,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
-import tech.pegasys.artemis.bls.BLS;
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSPublicKey;
-import tech.pegasys.artemis.bls.BLSSecretKey;
-import tech.pegasys.artemis.bls.BLSSignature;
 import tech.pegasys.eth2signer.dsl.HashicorpSigningParams;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.signers.bls.keystore.model.KdfFunction;
 import tech.pegasys.signers.hashicorp.dsl.DockerClientFactory;
 import tech.pegasys.signers.hashicorp.dsl.HashicorpNode;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSecretKey;
+import tech.pegasys.teku.bls.BLSSignature;
 
 import java.nio.file.Path;
 

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/PublicKeysAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/PublicKeysAcceptanceTest.java
@@ -17,11 +17,11 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSPublicKey;
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -18,6 +18,7 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import tech.pegasys.eth2signer.core.http.models.SigningRequestBody;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
+import tech.pegasys.teku.bls.BLSSignature;
 
 import java.util.Optional;
 
@@ -29,7 +30,6 @@ import io.vertx.ext.web.api.RequestParameters;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.bls.BLSSignature;
 
 public class SignForPublicKeyHandler implements Handler<RoutingContext> {
   private static final Logger LOG = LogManager.getLogger();

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -15,7 +15,6 @@ package tech.pegasys.eth2signer.core.http.handlers;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 
-import tech.pegasys.artemis.bls.BLSSignature;
 import tech.pegasys.eth2signer.core.http.models.SigningRequestBody;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
@@ -30,6 +29,7 @@ import io.vertx.ext.web.api.RequestParameters;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignature;
 
 public class SignForPublicKeyHandler implements Handler<RoutingContext> {
   private static final Logger LOG = LogManager.getLogger();

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -15,8 +15,6 @@ package tech.pegasys.eth2signer.core.multikey.metadata;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.metrics.Eth2SignerMetricCategory;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.signers.bls.keystore.KeyStore;
@@ -41,6 +39,8 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class ArtifactSignerFactory {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -27,6 +27,8 @@ import tech.pegasys.signers.hashicorp.TrustStoreType;
 import tech.pegasys.signers.hashicorp.config.ConnectionParameters;
 import tech.pegasys.signers.hashicorp.config.KeyDefinition;
 import tech.pegasys.signers.hashicorp.config.TlsOptions;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -39,8 +41,6 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext;
-import tech.pegasys.teku.bls.BLSKeyPair;
-import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class ArtifactSignerFactory {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
@@ -12,10 +12,10 @@
  */
 package tech.pegasys.eth2signer.core.multikey.metadata;
 
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class FileRawSigningMetadata implements SigningMetadata {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/FileRawSigningMetadata.java
@@ -13,9 +13,9 @@
 package tech.pegasys.eth2signer.core.multikey.metadata;
 
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class FileRawSigningMetadata implements SigningMetadata {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 
 import java.io.IOException;
@@ -25,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class SigningMetadataModule extends SimpleModule {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/SigningMetadataModule.java
@@ -13,6 +13,7 @@
 package tech.pegasys.eth2signer.core.multikey.metadata.parser;
 
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import java.io.IOException;
 
@@ -24,7 +25,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.bls.BLSSecretKey;
 
 public class SigningMetadataModule extends SimpleModule {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
@@ -12,11 +12,11 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-
-import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
+
+import org.apache.tuweni.bytes.Bytes;
 
 public class ArtifactSigner {
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
@@ -12,11 +12,11 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import tech.pegasys.artemis.bls.BLS;
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSSignature;
 
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSignature;
 
 public class ArtifactSigner {
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -20,12 +20,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.TrackingLogAppender;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -19,13 +19,13 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.artemis.bls.BLSKeyPair;
-import tech.pegasys.artemis.bls.BLSSecretKey;
 import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileRawSigningMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSecretKey;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -78,7 +78,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
 
-    dependency 'tech.pegasys.teku.internal:bls:0.8.2-SNAPSHOT'
+    dependency 'tech.pegasys.teku.internal:bls:0.12.1-SNAPSHOT'
     dependency 'tech.pegasys.signers.internal:keystorage-hashicorp:1.0.0'
 
     dependency 'com.atlassian.oai:swagger-request-validator-restassured:2.10.0'


### PR DESCRIPTION
Updates to latest BLS version so that Eth2Signer will work the latest version of BLS used in Etheruem 2.