### PR TITLE
Use signers 1.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ jobs:
           no_output_timeout: 20m
           command: |
             ./gradlew --no-daemon --parallel integrationTest --info
+      - run:
+          name: Acceptance Test
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel acceptanceTest
       - notify      
       - capture_test_results
       - capture_test_reports
@@ -223,9 +228,6 @@ workflows:
   default:
     jobs:
       - build
-      - acceptanceTests:
-          requires:
-            - build
       - buildDocker:
           requires:
             - build
@@ -237,7 +239,6 @@ workflows:
                 - /^release-.*/
           requires:
             - build
-            - acceptanceTests
       - publish:
           filters:
             branches:
@@ -246,7 +247,6 @@ workflows:
                 - /^release-.*/
           requires:
             - build
-            - acceptanceTests
       - publishDocker:
           filters:
             branches:
@@ -255,5 +255,4 @@ workflows:
                 - /^release-.*/
           requires:
             - build
-            - acceptanceTests
             - buildDocker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,6 @@ executors:
       JAVA_TOOL_OPTIONS: -Xmx4096m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096m
 
-  executor_machine: # 2cpu , 8G ram
-    machine:
-      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
-      docker_layer_caching: true
-    working_directory: ~/project
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx4096m
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2 -Xmx4096m
-
   executor_node:
     docker:
       - image: circleci/node:14-buster
@@ -129,27 +120,6 @@ jobs:
           root: ~/project
           paths:
             - ./
-
-  acceptanceTests:
-    executor: executor_machine
-    steps:
-      - prepare
-      - run:
-          name: Install Packages - Java 11
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13 5DC22404A6F9F1CA
-            sudo add-apt-repository -y ppa:openjdk-r/ppa
-            sudo apt update
-            sudo apt install -y openjdk-11-jdk
-            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
-      - run:
-          name: Acceptance Test
-          no_output_timeout: 20m
-          command: |
-            ./gradlew --no-daemon --parallel acceptanceTest
-      - notify            
-      - capture_test_results
-      - capture_test_reports
 
   buildDocker:
     executor: executor_med

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -11,6 +11,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
+plugins {
+  id "de.undercouch.download" version "4.1.0"
+  id "com.google.osdetector" version "1.6.2"
+}
+
 dependencies {
 
   testImplementation project(":app")
@@ -21,8 +26,8 @@ dependencies {
   testRuntimeOnly 'javax.activation:activation'
   testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testRuntimeOnly 'org.zeroturnaround:zt-exec'
 
-  testImplementation 'com.github.docker-java:docker-java'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'
   testImplementation 'io.vertx:vertx-core'
@@ -40,15 +45,57 @@ dependencies {
 
 test.enabled = false
 
-task acceptanceTest(type: Test) {
+def vaultBinary () {
+  switch (osdetector.os) {
+    case "windows":
+      return new File(buildDir, "vault.exe").toString()
+    default:
+      return new File(buildDir, "vault").toString()
+  }
+}
+
+def vaultDownloadUrl() {
+  // see gradle.properties for Hashicorp Vault URL
+  switch (osdetector.os) {
+    case "windows":
+      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_windows_amd64.zip"
+      break
+    case "linux":
+      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_linux_amd64.zip"
+      break
+    case "osx":
+      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_darwin_amd64.zip"
+      break
+  }
+}
+
+task downloadVault(type: Download) {
+  src {
+    return vaultDownloadUrl()
+  }
+  dest new File(buildDir, "hashicorp.zip")
+  onlyIfModified true
+}
+
+task extractVault(dependsOn: downloadVault, type: Copy) {
+  from zipTree(downloadVault.dest)
+  into buildDir
+}
+
+task acceptanceTest(dependsOn: [
+  rootProject.installDist,
+  extractVault
+], type: Test) {
+  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
+
   mustRunAfter rootProject.subprojects*.test
   description = 'Runs Eth2Signer acceptance tests.'
   group = 'verification'
 
   systemProperty 'acctests.runEth2SignerAsProcess', 'true'
+  systemProperty 'vaultBinary', vaultBinary()
 
   useJUnitPlatform()
   // toggle to show standard out and standard error of the test JVM(s) on the console
   testLogging.showStandardStreams = false
 }
-acceptanceTest.dependsOn(rootProject.installDist)

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/KeyLoadAndSignAcceptanceTest.java
@@ -21,7 +21,6 @@ import tech.pegasys.eth2signer.dsl.HashicorpSigningParams;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.signers.bls.keystore.model.KdfFunction;
-import tech.pegasys.signers.hashicorp.dsl.DockerClientFactory;
 import tech.pegasys.signers.hashicorp.dsl.HashicorpNode;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -220,9 +219,7 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
   @Test
   public void ableToSignUsingHashicorp() {
     final String configFilename = keyPair.getPublicKey().toString().substring(2);
-    final DockerClientFactory dockerClientFactory = new DockerClientFactory();
-    final HashicorpNode hashicorpNode =
-        HashicorpNode.createAndStartHashicorp(dockerClientFactory.create(), true);
+    final HashicorpNode hashicorpNode = HashicorpNode.createAndStartHashicorp(true);
     try {
       final String secretPath = "acceptanceTestSecretPath";
       final String secretName = "secretName";

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1g
 version=0.1.1-SNAPSHOT
+hashicorpVaultVersion=1.4.3
+hashicorpVaultUrl=https://releases.hashicorp.com/vault

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,8 +16,6 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1'
 
-    dependency 'com.github.docker-java:docker-java:3.2.2'
-
     dependency 'com.google.errorprone:error_prone_annotation:2.3.4'
     dependency 'com.google.errorprone:error_prone_check_api:2.3.4'
     dependency 'com.google.errorprone:error_prone_core:2.3.4'
@@ -76,11 +74,14 @@ dependencyManagement {
     dependency 'org.hyperledger.besu.internal:metrics-core:1.4.0'
     dependency 'org.hyperledger.besu:plugin-api:1.4.0'
 
-    dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.0'
-
     dependency 'tech.pegasys.teku.internal:bls:0.12.1-SNAPSHOT'
-    dependency 'tech.pegasys.signers.internal:keystorage-hashicorp:1.0.0'
+
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2') {
+      entry 'bls-keystore'
+      entry 'keystorage-hashicorp'
+    }
 
     dependency 'com.atlassian.oai:swagger-request-validator-restassured:2.10.0'
+    dependency 'org.zeroturnaround:zt-exec:1.11'
   }
 }


### PR DESCRIPTION
 * Allow to use Hashicorp Vault local instance in acceptance test
 * Update CircleCI to not use machine instance anymore
 * Remove docker-api dependency

Signed-off-by: Usman Saleem <usman@usmans.info>