### PR TITLE
Typed artifact signature

### DIFF
--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.eth2signer.core;
 
+import static tech.pegasys.eth2signer.core.signing.ArtifactSignatureType.BLS;
+
 import tech.pegasys.eth2signer.core.config.ClientAuthConstraints;
 import tech.pegasys.eth2signer.core.config.Config;
 import tech.pegasys.eth2signer.core.config.TlsOptions;
@@ -25,6 +27,7 @@ import tech.pegasys.eth2signer.core.metrics.VertxMetricsAdapterFactory;
 import tech.pegasys.eth2signer.core.multikey.DirectoryBackedArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.YamlSignerParser;
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
 import tech.pegasys.eth2signer.core.util.FileUtil;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 
@@ -150,11 +153,16 @@ public class Runner implements Runnable {
         GET_PUBLIC_KEYS_OPERATION_ID, errorHandler);
 
     openAPI3RouterFactory.addHandlerByOperationId(
-        SIGN_FOR_PUBLIC_KEY_OPERATION_ID, new SignForPublicKeyHandler(signerProvider));
+        SIGN_FOR_PUBLIC_KEY_OPERATION_ID,
+        new SignForPublicKeyHandler<>(signerProvider, this::formatBlsSignature, BLS));
     openAPI3RouterFactory.addFailureHandlerByOperationId(
         SIGN_FOR_PUBLIC_KEY_OPERATION_ID, errorHandler);
 
     return openAPI3RouterFactory;
+  }
+
+  private String formatBlsSignature(final BlsArtifactSignature signature) {
+    return signature.getSignatureData().toString();
   }
 
   private OpenAPI3RouterFactory getOpenAPI3RouterFactory(final Vertx vertx)

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -36,7 +36,7 @@ public class SignForPublicKeyHandler<T extends ArtifactSignature>
     implements Handler<RoutingContext> {
   private static final Logger LOG = LogManager.getLogger();
   final ArtifactSignerProvider signerProvider;
-  private SignatureFormatter<T> signatureFormatter;
+  private final SignatureFormatter<T> signatureFormatter;
   private final ArtifactSignatureType type;
 
   public SignForPublicKeyHandler(

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -72,8 +72,8 @@ public class SignForPublicKeyHandler<T extends ArtifactSignature>
   @SuppressWarnings("unchecked")
   private String formatSignature(final ArtifactSignature signature) {
     if (signature.getType() == type) {
-      final T blsArtifactSignature = (T) signature;
-      return signatureFormatter.format(blsArtifactSignature);
+      final T artifactSignature = (T) signature;
+      return signatureFormatter.format(artifactSignature);
     } else {
       throw new IllegalStateException("Invalid signature type");
     }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -41,8 +41,8 @@ public class SignForPublicKeyHandler<T extends ArtifactSignature>
 
   public SignForPublicKeyHandler(
       final ArtifactSignerProvider signerProvider,
-      SignatureFormatter<T> signatureFormatter,
-      ArtifactSignatureType type) {
+      final SignatureFormatter<T> signatureFormatter,
+      final ArtifactSignatureType type) {
     this.signerProvider = signerProvider;
     this.signatureFormatter = signatureFormatter;
     this.type = type;

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -22,7 +22,6 @@ import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
@@ -37,15 +36,15 @@ public class SignForPublicKeyHandler<T extends ArtifactSignature>
     implements Handler<RoutingContext> {
   private static final Logger LOG = LogManager.getLogger();
   final ArtifactSignerProvider signerProvider;
-  private final Function<T, String> formatter;
+  private SignatureFormatter<T> signatureFormatter;
   private final ArtifactSignatureType type;
 
   public SignForPublicKeyHandler(
       final ArtifactSignerProvider signerProvider,
-      Function<T, String> formatter,
+      SignatureFormatter<T> signatureFormatter,
       ArtifactSignatureType type) {
     this.signerProvider = signerProvider;
-    this.formatter = formatter;
+    this.signatureFormatter = signatureFormatter;
     this.type = type;
   }
 
@@ -74,7 +73,7 @@ public class SignForPublicKeyHandler<T extends ArtifactSignature>
   private String formatSignature(final ArtifactSignature signature) {
     if (signature.getType() == type) {
       final T blsArtifactSignature = (T) signature;
-      return formatter.apply(blsArtifactSignature);
+      return signatureFormatter.format(blsArtifactSignature);
     } else {
       throw new IllegalStateException("Invalid signature type");
     }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignForPublicKeyHandler.java
@@ -16,11 +16,13 @@ import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 
 import tech.pegasys.eth2signer.core.http.models.SigningRequestBody;
+import tech.pegasys.eth2signer.core.signing.ArtifactSignature;
+import tech.pegasys.eth2signer.core.signing.ArtifactSignatureType;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
-import tech.pegasys.teku.bls.BLSSignature;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
@@ -31,12 +33,20 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 
-public class SignForPublicKeyHandler implements Handler<RoutingContext> {
+public class SignForPublicKeyHandler<T extends ArtifactSignature>
+    implements Handler<RoutingContext> {
   private static final Logger LOG = LogManager.getLogger();
   final ArtifactSignerProvider signerProvider;
+  private final Function<T, String> formatter;
+  private final ArtifactSignatureType type;
 
-  public SignForPublicKeyHandler(final ArtifactSignerProvider signerProvider) {
+  public SignForPublicKeyHandler(
+      final ArtifactSignerProvider signerProvider,
+      Function<T, String> formatter,
+      ArtifactSignatureType type) {
     this.signerProvider = signerProvider;
+    this.formatter = formatter;
+    this.type = type;
   }
 
   @Override
@@ -51,11 +61,23 @@ public class SignForPublicKeyHandler implements Handler<RoutingContext> {
     }
 
     final Bytes dataToSign = getDataToSign(params);
-    final BLSSignature signature = signer.get().sign(dataToSign);
+    final ArtifactSignature artifactSignature = signer.get().sign(dataToSign);
+    final String formatSignature = formatSignature(artifactSignature);
+
     routingContext
         .response()
         .putHeader(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString())
-        .end(signature.toString());
+        .end(formatSignature);
+  }
+
+  @SuppressWarnings("unchecked")
+  private String formatSignature(final ArtifactSignature signature) {
+    if (signature.getType() == type) {
+      final T blsArtifactSignature = (T) signature;
+      return formatter.apply(blsArtifactSignature);
+    } else {
+      throw new IllegalStateException("Invalid signature type");
+    }
   }
 
   private Bytes getDataToSign(final RequestParameters params) {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignatureFormatter.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignatureFormatter.java
@@ -14,6 +14,7 @@ package tech.pegasys.eth2signer.core.http.handlers;
 
 import tech.pegasys.eth2signer.core.signing.ArtifactSignature;
 
+@FunctionalInterface
 public interface SignatureFormatter<T extends ArtifactSignature> {
 
   String format(T signature);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignatureFormatter.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/http/handlers/SignatureFormatter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.http.handlers;
+
+import tech.pegasys.eth2signer.core.signing.ArtifactSignature;
+
+public interface SignatureFormatter<T extends ArtifactSignature> {
+
+  String format(T signature);
+}

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -69,7 +69,7 @@ public class ArtifactSignerFactory {
     }
   }
 
-  public BlsArtifactSigner create(final FileKeyStoreMetadata fileKeyStoreMetadata) {
+  public ArtifactSigner create(final FileKeyStoreMetadata fileKeyStoreMetadata) {
     try (TimingContext ignored = privateKeyRetrievalTimer.labels("file-keystore").startTimer()) {
       return createKeystoreArtifact(fileKeyStoreMetadata);
     }
@@ -81,7 +81,7 @@ public class ArtifactSignerFactory {
     }
   }
 
-  private BlsArtifactSigner createKeystoreArtifact(
+  private ArtifactSigner createKeystoreArtifact(
       final FileKeyStoreMetadata fileKeyStoreMetadata) {
     final Path keystoreFile = makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystoreFile());
     final Path keystorePasswordFile =

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -81,8 +81,7 @@ public class ArtifactSignerFactory {
     }
   }
 
-  private ArtifactSigner createKeystoreArtifact(
-      final FileKeyStoreMetadata fileKeyStoreMetadata) {
+  private ArtifactSigner createKeystoreArtifact(final FileKeyStoreMetadata fileKeyStoreMetadata) {
     final Path keystoreFile = makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystoreFile());
     final Path keystorePasswordFile =
         makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystorePasswordFile());

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/metadata/ArtifactSignerFactory.java
@@ -17,6 +17,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import tech.pegasys.eth2signer.core.metrics.Eth2SignerMetricCategory;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSigner;
 import tech.pegasys.signers.bls.keystore.KeyStore;
 import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
 import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
@@ -64,11 +65,11 @@ public class ArtifactSignerFactory {
 
   public ArtifactSigner create(final FileRawSigningMetadata fileRawSigningMetadata) {
     try (TimingContext ignored = privateKeyRetrievalTimer.labels("file-raw").startTimer()) {
-      return new ArtifactSigner(new BLSKeyPair(fileRawSigningMetadata.getSecretKey()));
+      return new BlsArtifactSigner(new BLSKeyPair(fileRawSigningMetadata.getSecretKey()));
     }
   }
 
-  public ArtifactSigner create(final FileKeyStoreMetadata fileKeyStoreMetadata) {
+  public BlsArtifactSigner create(final FileKeyStoreMetadata fileKeyStoreMetadata) {
     try (TimingContext ignored = privateKeyRetrievalTimer.labels("file-keystore").startTimer()) {
       return createKeystoreArtifact(fileKeyStoreMetadata);
     }
@@ -80,7 +81,8 @@ public class ArtifactSignerFactory {
     }
   }
 
-  private ArtifactSigner createKeystoreArtifact(final FileKeyStoreMetadata fileKeyStoreMetadata) {
+  private BlsArtifactSigner createKeystoreArtifact(
+      final FileKeyStoreMetadata fileKeyStoreMetadata) {
     final Path keystoreFile = makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystoreFile());
     final Path keystorePasswordFile =
         makeRelativePathAbsolute(fileKeyStoreMetadata.getKeystorePasswordFile());
@@ -89,7 +91,7 @@ public class ArtifactSignerFactory {
       final String password = loadPassword(keystorePasswordFile);
       final Bytes privateKey = KeyStore.decrypt(password, keyStoreData);
       final BLSKeyPair keyPair = new BLSKeyPair(BLSSecretKey.fromBytes(privateKey));
-      return new ArtifactSigner(keyPair);
+      return new BlsArtifactSigner(keyPair);
     } catch (final KeyStoreValidationException e) {
       throw new SigningMetadataException(e.getMessage(), e);
     }
@@ -128,7 +130,7 @@ public class ArtifactSignerFactory {
                   metadata.getToken()));
       final BLSKeyPair keyPair =
           new BLSKeyPair(BLSSecretKey.fromBytes(Bytes.fromHexString(secret)));
-      return new ArtifactSigner(keyPair);
+      return new BlsArtifactSigner(keyPair);
     } catch (Exception e) {
       throw new SigningMetadataException("Failed to fetch secret from hashicorp vault", e);
     }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSignature.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSignature.java
@@ -12,11 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import org.apache.tuweni.bytes.Bytes;
+public interface ArtifactSignature {
 
-public interface ArtifactSigner {
-
-  String getIdentifier();
-
-  ArtifactSignature sign(final Bytes message);
+  ArtifactSignatureType getType();
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSignatureType.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSignatureType.java
@@ -12,11 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import org.apache.tuweni.bytes.Bytes;
-
-public interface ArtifactSigner {
-
-  String getIdentifier();
-
-  ArtifactSignature sign(final Bytes message);
+public enum ArtifactSignatureType {
+  BLS
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
@@ -18,5 +18,5 @@ public interface ArtifactSigner {
 
   String getIdentifier();
 
-  ArtifactSignature sign(final Bytes message);
+  ArtifactSignature sign(final Bytes data);
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignature.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignature.java
@@ -12,11 +12,21 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignature;
 
-public interface ArtifactSigner {
+public class BlsArtifactSignature implements ArtifactSignature {
+  private final BLSSignature blsSignature;
 
-  String getIdentifier();
+  public BlsArtifactSignature(final BLSSignature blsSignature) {
+    this.blsSignature = blsSignature;
+  }
 
-  ArtifactSignature sign(final Bytes message);
+  @Override
+  public ArtifactSignatureType getType() {
+    return ArtifactSignatureType.BLS;
+  }
+
+  public BLSSignature getSignatureData() {
+    return blsSignature;
+  }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
@@ -31,7 +31,7 @@ public class BlsArtifactSigner implements ArtifactSigner {
   }
 
   @Override
-  public ArtifactSignature sign(final Bytes message) {
-    return new BlsArtifactSignature(BLS.sign(keyPair.getSecretKey(), message));
+  public ArtifactSignature sign(final Bytes data) {
+    return new BlsArtifactSignature(BLS.sign(keyPair.getSecretKey(), data));
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
@@ -12,11 +12,26 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+
 import org.apache.tuweni.bytes.Bytes;
 
-public interface ArtifactSigner {
+public class BlsArtifactSigner implements ArtifactSigner {
 
-  String getIdentifier();
+  private final BLSKeyPair keyPair;
 
-  ArtifactSignature sign(final Bytes message);
+  public BlsArtifactSigner(final BLSKeyPair keyPair) {
+    this.keyPair = keyPair;
+  }
+
+  @Override
+  public String getIdentifier() {
+    return keyPair.getPublicKey().toString();
+  }
+
+  @Override
+  public ArtifactSignature sign(final Bytes message) {
+    return new BlsArtifactSignature(BLS.sign(keyPair.getSecretKey(), message));
+  }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
@@ -19,7 +19,7 @@ import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.HashicorpSigningMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
-import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSigner;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 
 import java.io.IOException;
@@ -70,7 +70,7 @@ class ArtifactSignerFactoryTest {
   void createsArtifactSignerFromKeyStoreUsingRelativePaths() {
     final Path relativeKeystorePath = Path.of(KEYSTORE_FILE);
     final Path relativePasswordPath = Path.of(PASSWORD_FILE);
-    final ArtifactSigner artifactSigner =
+    final BlsArtifactSigner artifactSigner =
         artifactSignerFactory.create(
             new FileKeyStoreMetadata(relativeKeystorePath, relativePasswordPath));
 
@@ -82,7 +82,7 @@ class ArtifactSignerFactoryTest {
   @Test
   void createsArtifactSignerFromKeyStoreUsingAbsolutePaths() {
 
-    final ArtifactSigner artifactSigner =
+    final BlsArtifactSigner artifactSigner =
         artifactSignerFactory.create(new FileKeyStoreMetadata(keystoreFile, passwordFile));
 
     assertThat(keystoreFile).isAbsolute();

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/ArtifactSignerFactoryTest.java
@@ -19,7 +19,7 @@ import tech.pegasys.eth2signer.core.multikey.metadata.ArtifactSignerFactory;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.HashicorpSigningMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
-import tech.pegasys.eth2signer.core.signing.BlsArtifactSigner;
+import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 
 import java.io.IOException;
@@ -70,7 +70,7 @@ class ArtifactSignerFactoryTest {
   void createsArtifactSignerFromKeyStoreUsingRelativePaths() {
     final Path relativeKeystorePath = Path.of(KEYSTORE_FILE);
     final Path relativePasswordPath = Path.of(PASSWORD_FILE);
-    final BlsArtifactSigner artifactSigner =
+    final ArtifactSigner artifactSigner =
         artifactSignerFactory.create(
             new FileKeyStoreMetadata(relativeKeystorePath, relativePasswordPath));
 
@@ -81,8 +81,7 @@ class ArtifactSignerFactoryTest {
 
   @Test
   void createsArtifactSignerFromKeyStoreUsingAbsolutePaths() {
-
-    final BlsArtifactSigner artifactSigner =
+    final ArtifactSigner artifactSigner =
         artifactSignerFactory.create(new FileKeyStoreMetadata(keystoreFile, passwordFile));
 
     assertThat(keystoreFile).isAbsolute();

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProviderTest.java
@@ -24,6 +24,7 @@ import tech.pegasys.eth2signer.TrackingLogAppender;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSigner;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 
@@ -407,7 +408,7 @@ class DirectoryBackedArtifactSignerProviderTest {
   }
 
   private ArtifactSigner createArtifactSigner(final String privateKey) {
-    return new ArtifactSigner(
+    return new BlsArtifactSigner(
         new BLSKeyPair(BLSSecretKey.fromBytes(Bytes.fromHexString(privateKey))));
   }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -24,6 +24,7 @@ import tech.pegasys.eth2signer.core.multikey.metadata.FileKeyStoreMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.FileRawSigningMetadata;
 import tech.pegasys.eth2signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.eth2signer.core.signing.ArtifactSigner;
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSigner;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 
@@ -47,7 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class YamlSignerParserTest {
 
   private static final String YAML_FILE_EXTENSION = "yaml";
-  private static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
   private static final String PRIVATE_KEY =
       "3ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
 
@@ -114,7 +115,7 @@ class YamlSignerParserTest {
   @Test
   void unencryptedMetaDataInfoWithPrivateKeyReturnsMetadata() throws IOException {
     final ArtifactSigner artifactSigner =
-        new ArtifactSigner(
+        new BlsArtifactSigner(
             new BLSKeyPair(BLSSecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY))));
     when(artifactSignerFactory.create(any(FileRawSigningMetadata.class)))
         .thenReturn(artifactSigner);
@@ -134,7 +135,7 @@ class YamlSignerParserTest {
   @Test
   void unencryptedMetaDataInfoWith0xPrefixPrivateKeyReturnsMetadata() throws IOException {
     final ArtifactSigner artifactSigner =
-        new ArtifactSigner(
+        new BlsArtifactSigner(
             new BLSKeyPair(BLSSecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY))));
     when(artifactSignerFactory.create(any(FileRawSigningMetadata.class)))
         .thenReturn(artifactSigner);
@@ -193,8 +194,8 @@ class YamlSignerParserTest {
 
   @Test
   void keyStoreMetaDataInfoReturnsMetadata() throws IOException {
-    final ArtifactSigner artifactSigner =
-        new ArtifactSigner(
+    final BlsArtifactSigner artifactSigner =
+        new BlsArtifactSigner(
             new BLSKeyPair(
                 BLSSecretKey.fromBytes(Bytes48.leftPad(Bytes.fromHexString(PRIVATE_KEY)))));
     when(artifactSignerFactory.create(any(FileKeyStoreMetadata.class))).thenReturn(artifactSigner);

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignatureTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignatureTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.signing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.teku.bls.BLSSignature;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class BlsArtifactSignatureTest {
+  private static final String SIGNATURE =
+      "0x932603f10c7efd5320596aece2750b6f0fbc982b818f3a571b3a8522eec08d85362deffd27a79210b0d2a64a431afaf60ed4fe882224b70fa4cf9e6af2b08caf1fbb9c9498bf4dee157e261e8ec74755b740a1cb60cd83becf8201d81d2f7cff";
+
+  @Test
+  void hexEncodedSignatureIsReturned() {
+    final BLSSignature blsSignature = BLSSignature.fromBytes(Bytes.fromHexString(SIGNATURE));
+    final BlsArtifactSignature blsArtifactSignature = new BlsArtifactSignature(blsSignature);
+    assertThat(blsArtifactSignature.getSignatureData().toString()).isEqualTo(SIGNATURE);
+    assertThat(blsSignature.toBytes().toHexString()).isEqualTo(SIGNATURE);
+    assertThat(blsSignature.getSignature().toString()).isEqualTo(SIGNATURE);
+  }
+}

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignerTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.signing;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSSignature;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class BlsArtifactSignerTest {
+
+  @Test
+  void publicKeyIsReturnedAsIdentifier() {
+    final BLSKeyPair keyPair = BLSKeyPair.random(4);
+    final BlsArtifactSigner blsArtifactSigner = new BlsArtifactSigner(keyPair);
+    assertThat(blsArtifactSigner.getIdentifier()).isEqualTo(keyPair.getPublicKey().toString());
+  }
+
+  @Test
+  void signsData() {
+    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
+    final BLSKeyPair keyPair = BLSKeyPair.random(4);
+    final BLSSignature expectedSignature = BLS.sign(keyPair.getSecretKey(), message);
+
+    final BlsArtifactSigner blsArtifactSigner = new BlsArtifactSigner(keyPair);
+    final BlsArtifactSignature signature = (BlsArtifactSignature) blsArtifactSigner.sign(message);
+
+    assertThat(signature.getSignatureData().toString()).isEqualTo(expectedSignature.toString());
+  }
+}


### PR DESCRIPTION
Refactor ArtifactSignerProvider and underlying types so that it can return different signatures. This will allow us to sign with other cryptos other BLS in future.