### PR TITLE
Bump lodash from 4.17.15 to 4.17.19 for openapidoc npm dependency

### DIFF
--- a/.openapidoc/package-lock.json
+++ b/.openapidoc/package-lock.json
@@ -838,9 +838,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "mimic-fn": {
       "version": "2.1.0",


### PR DESCRIPTION
Signed-off-by: Usman Saleem <usman@usmans.info>