### PR TITLE
Refactor signing ATs to use common signing request

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/BlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/BlsSigningAcceptanceTest.java
@@ -12,15 +12,11 @@
  */
 package tech.pegasys.eth2signer.tests.signing;
 
-import static io.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 import tech.pegasys.eth2signer.dsl.HashicorpSigningParams;
-import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
-import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
 import tech.pegasys.signers.bls.keystore.model.KdfFunction;
 import tech.pegasys.signers.hashicorp.dsl.HashicorpNode;
 import tech.pegasys.teku.bls.BLS;
@@ -31,15 +27,12 @@ import tech.pegasys.teku.bls.BLSSignature;
 
 import java.nio.file.Path;
 
-import io.restassured.http.ContentType;
-import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-public class BlsSigningAcceptanceTest extends AcceptanceTestBase {
+public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
 
   private static final Bytes DATA = Bytes.wrap("Hello, world!".getBytes(UTF_8));
   private static final String PRIVATE_KEY =
@@ -50,9 +43,6 @@ public class BlsSigningAcceptanceTest extends AcceptanceTestBase {
   private static final BLSKeyPair keyPair = new BLSKeyPair(key);
   private static final BLSPublicKey publicKey = keyPair.getPublicKey();
   private static final BLSSignature expectedSignature = BLS.sign(keyPair.getSecretKey(), DATA);
-  private static final String SIGN_ENDPOINT = "/signer/sign/{identifier}";
-
-  @TempDir Path testDirectory;
 
   @Test
   public void signDataWithKeyLoadedFromUnencryptedFile() {
@@ -60,21 +50,9 @@ public class BlsSigningAcceptanceTest extends AcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
-
-    given()
-        .baseUri(signer.getUrl())
-        .filter(getOpenApiValidationFilter())
-        .contentType(ContentType.JSON)
-        .pathParam("identifier", keyPair.getPublicKey().toString())
-        .body(new JsonObject().put("data", DATA.toHexString()).toString())
-        .post(SIGN_ENDPOINT)
-        .then()
-        .statusCode(200)
-        .contentType(ContentType.TEXT)
-        .body(equalToIgnoringCase(expectedSignature.toString()));
+    setupSigner();
+    verifySignature(
+        keyPair.getPublicKey().toString(), DATA.toHexString(), expectedSignature.toString());
   }
 
   @ParameterizedTest
@@ -85,21 +63,9 @@ public class BlsSigningAcceptanceTest extends AcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createKeyStoreYamlFileAt(keyConfigFile, keyPair, kdfFunction);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
-
-    given()
-        .baseUri(signer.getUrl())
-        .filter(getOpenApiValidationFilter())
-        .contentType(ContentType.JSON)
-        .pathParam("identifier", keyPair.getPublicKey().toString())
-        .body(new JsonObject().put("data", DATA.toHexString()).toString())
-        .post(SIGN_ENDPOINT)
-        .then()
-        .statusCode(200)
-        .contentType(ContentType.TEXT)
-        .body(equalToIgnoringCase(expectedSignature.toString()));
+    setupSigner();
+    verifySignature(
+        keyPair.getPublicKey().toString(), DATA.toHexString(), expectedSignature.toString());
   }
 
   @Test
@@ -116,22 +82,9 @@ public class BlsSigningAcceptanceTest extends AcceptanceTestBase {
       metadataFileHelpers.createHashicorpYamlFileAt(
           keyConfigFile, new HashicorpSigningParams(hashicorpNode, secretPath, secretName));
 
-      final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-      builder.withKeyStoreDirectory(testDirectory);
-      startSigner(builder.build());
-
-      given()
-          .baseUri(signer.getUrl())
-          .filter(getOpenApiValidationFilter())
-          .contentType(ContentType.JSON)
-          .pathParam("identifier", keyPair.getPublicKey().toString())
-          .body(new JsonObject().put("data", DATA.toHexString()).toString())
-          .when()
-          .post(SIGN_ENDPOINT)
-          .then()
-          .assertThat()
-          .statusCode(200)
-          .body(equalToIgnoringCase(expectedSignature.toString()));
+      setupSigner();
+      verifySignature(
+          keyPair.getPublicKey().toString(), DATA.toHexString(), expectedSignature.toString());
     } finally {
       hashicorpNode.shutdown();
     }

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
-import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -31,9 +30,8 @@ import io.restassured.http.ContentType;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
+public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
 
   private static final Bytes DATA = Bytes.wrap("Hello, world!".getBytes(UTF_8));
   private static final String PRIVATE_KEY =
@@ -45,8 +43,6 @@ public class KeyLoadAndSignAcceptanceTest extends AcceptanceTestBase {
   private static final BLSPublicKey publicKey = keyPair.getPublicKey();
   private static final BLSSignature expectedSignature = BLS.sign(keyPair.getSecretKey(), DATA);
   private static final String SIGN_ENDPOINT = "/signer/sign/{identifier}";
-
-  @TempDir Path testDirectory;
 
   @Test
   public void receiveA404IfRequestedKeyDoesNotExist() {

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
@@ -16,7 +16,6 @@ import static io.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
-import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
 import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -42,13 +41,10 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
   private static final BLSKeyPair keyPair = new BLSKeyPair(key);
   private static final BLSPublicKey publicKey = keyPair.getPublicKey();
   private static final BLSSignature expectedSignature = BLS.sign(keyPair.getSecretKey(), DATA);
-  private static final String SIGN_ENDPOINT = "/signer/sign/{identifier}";
 
   @Test
   public void receiveA404IfRequestedKeyDoesNotExist() {
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    startSigner(builder.build());
-
+    setupSigner();
     given()
         .baseUri(signer.getUrl())
         .filter(getOpenApiValidationFilter())
@@ -68,9 +64,7 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+    setupSigner();
 
     // without client-side openapi validator
     given()
@@ -91,9 +85,7 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+    setupSigner();
 
     // without OpenAPI validation filter
     given()
@@ -114,9 +106,7 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+    setupSigner();
 
     // without OpenAPI validation filter
     given()
@@ -137,9 +127,7 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
     metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY);
 
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+    setupSigner();
 
     given()
         .baseUri(signer.getUrl())

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.signers.secp256k1.MultiKeyTomlFileUtil.createFileBase
 import static tech.pegasys.signers.secp256k1.MultiKeyTomlFileUtil.createHashicorpTomlFileAt;
 
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
-import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
 import tech.pegasys.signers.hashicorp.dsl.HashicorpNode;
 import tech.pegasys.signers.secp256k1.HashicorpSigningParams;
 
@@ -46,7 +45,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
 import org.junit.jupiter.api.io.TempDir;
 import org.web3j.crypto.Sign.SignatureData;
 
-public class SecpSigningAcceptanceTest extends AcceptanceTestBase {
+public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
   private static final byte[] DATA_TO_SIGN = "42".getBytes(UTF_8);
   private static final String PRIVATE_KEY =
       "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/SigningAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/signing/SigningAcceptanceTestBase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.tests.signing;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+
+import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
+import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
+
+import java.nio.file.Path;
+
+import io.restassured.http.ContentType;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SigningAcceptanceTestBase extends AcceptanceTestBase {
+  @TempDir Path testDirectory;
+  static final String SIGN_ENDPOINT = "/signer/sign/{identifier}";
+
+  protected void setupSigner() {
+    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
+    builder.withKeyStoreDirectory(testDirectory);
+    startSigner(builder.build());
+  }
+
+  protected void verifySignature(
+      final String publicKey, final String dataToSign, final String expectedSignature) {
+    given()
+        .baseUri(signer.getUrl())
+        .filter(getOpenApiValidationFilter())
+        .contentType(ContentType.JSON)
+        .pathParam("identifier", publicKey)
+        .body(new JsonObject().put("data", dataToSign).toString())
+        .post(SIGN_ENDPOINT)
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.TEXT)
+        .body(equalToIgnoringCase(expectedSignature));
+  }
+}


### PR DESCRIPTION
Refactor signing ATs to use common signing request. This removes a significant amount of duplicated code for the signing ATs and makes the tests simpler.