### PR TITLE
Ignore hidden key files

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
   testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
+  testFixturesImplementation 'commons-lang:commons-lang'
 }
 
 artifacts {

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -171,9 +171,9 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
   }
 
   private boolean matchesFileExtension(final Path filename) {
-    final boolean hidden = filename.toFile().isHidden();
+    final boolean isHidden = filename.toFile().isHidden();
     final String extension = FilenameUtils.getExtension(filename.toString());
-    return !hidden && extension.toLowerCase().endsWith(fileExtension.toLowerCase());
+    return !isHidden && extension.toLowerCase().endsWith(fileExtension.toLowerCase());
   }
 
   private boolean signerMatchesIdentifier(

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -164,8 +164,9 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
 
   private Filter<Path> signerIdentifierFilenameFilter(final String signerIdentifier) {
     return entry -> {
+      final boolean hidden = entry.toFile().isHidden();
       final String baseName = FilenameUtils.getBaseName(entry.toString());
-      return matchesFileExtension(entry)
+      return !hidden && matchesFileExtension(entry)
           && baseName.toLowerCase().endsWith(signerIdentifier.toLowerCase());
     };
   }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/multikey/DirectoryBackedArtifactSignerProvider.java
@@ -164,16 +164,16 @@ public class DirectoryBackedArtifactSignerProvider implements ArtifactSignerProv
 
   private Filter<Path> signerIdentifierFilenameFilter(final String signerIdentifier) {
     return entry -> {
-      final boolean hidden = entry.toFile().isHidden();
       final String baseName = FilenameUtils.getBaseName(entry.toString());
-      return !hidden && matchesFileExtension(entry)
+      return matchesFileExtension(entry)
           && baseName.toLowerCase().endsWith(signerIdentifier.toLowerCase());
     };
   }
 
   private boolean matchesFileExtension(final Path filename) {
+    final boolean hidden = filename.toFile().isHidden();
     final String extension = FilenameUtils.getExtension(filename.toString());
-    return extension.toLowerCase().endsWith(fileExtension.toLowerCase());
+    return !hidden && extension.toLowerCase().endsWith(fileExtension.toLowerCase());
   }
 
   private boolean signerMatchesIdentifier(

--- a/core/src/testFixtures/java/tech/pegasys/eth2signer/FileHiddenUtil.java
+++ b/core/src/testFixtures/java/tech/pegasys/eth2signer/FileHiddenUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.lang.SystemUtils;
+
+public class FileHiddenUtil {
+
+  public static void makeFileHidden(final Path file) throws IOException {
+    if (SystemUtils.IS_OS_WINDOWS) {
+      Files.setAttribute(file, "dos:hidden", true);
+    } else {
+      final File hiddenFile = file.getParent().resolve("." + file.getFileName()).toFile();
+      file.toFile().renameTo(hiddenFile);
+    }
+  }
+}


### PR DESCRIPTION
Ignore hidden files in the key directory as these are created by external tools and OS and are not config files. Whilst Eth2signer will start up correctly if it encounters an invalid or duplicate key file it creates unnecessary log noise.

#142 