### PR TITLE
Terminate Idle Connections

### DIFF
--- a/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
+++ b/commandline/src/main/java/tech/pegasys/eth2signer/commandline/Eth2SignerCommand.java
@@ -164,6 +164,14 @@ public class Eth2SignerCommand implements Config, Runnable {
       defaultValue = "localhost,127.0.0.1")
   private final AllowListHostsProperty metricsHostAllowList = new AllowListHostsProperty();
 
+  @Option(
+      names = {"--idle-connection-timeout-seconds"},
+      paramLabel = "<timeout in seconds>",
+      description =
+          "Number of seconds after which an idle connection will be terminated (Default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private int idleConnectionTimeoutSeconds = 30;
+
   @ArgGroup(exclusive = false)
   private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
@@ -233,6 +241,11 @@ public class Eth2SignerCommand implements Config, Runnable {
   }
 
   @Override
+  public int getIdleConnectionTimeoutSeconds() {
+    return idleConnectionTimeoutSeconds;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("configFile", configFile)
@@ -249,6 +262,7 @@ public class Eth2SignerCommand implements Config, Runnable {
         .add("metricCategories", metricCategories)
         .add("metricsHostAllowList", metricsHostAllowList)
         .add("picoCliTlsServerOptions", picoCliTlsServerOptions)
+        .add("idleConnectionTimeoutSeconds", idleConnectionTimeoutSeconds)
         .toString();
   }
 

--- a/commandline/src/test-support/java/tech/pegasys/eth2signer/CmdlineHelpers.java
+++ b/commandline/src/test-support/java/tech/pegasys/eth2signer/CmdlineHelpers.java
@@ -20,6 +20,7 @@ public class CmdlineHelpers {
     return "--http-listen-port=5001 "
         + "--http-listen-host=localhost "
         + "--key-store-path=./keys "
+        + "--idle-connection-timeout-seconds=45 "
         + "--logging=INFO ";
   }
 

--- a/commandline/src/test/java/tech/pegasys/eth2signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/eth2signer/commandline/CommandlineParserTest.java
@@ -57,6 +57,7 @@ class CommandlineParserTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.INFO);
     assertThat(config.getHttpListenHost()).isEqualTo("localhost");
     assertThat(config.getHttpListenPort()).isEqualTo(5001);
+    assertThat(config.getIdleConnectionTimeoutSeconds()).isEqualTo(45);
   }
 
   @Test
@@ -92,6 +93,12 @@ class CommandlineParserTest {
     final int result = parser.parseCommandLine("--nonExistentOption=9");
     assertThat(result).isNotZero();
     assertThat(commandOutput.toString()).containsOnlyOnce(defaultUsageText);
+  }
+
+  @Test
+  void missingIdleConnectionDefaultsToThirtySeconds() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "idle-connection-timeout-seconds", config::getIdleConnectionTimeoutSeconds, 30);
   }
 
   private <T> void missingOptionalParameterIsValidAndMeetsDefault(

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -279,7 +279,6 @@ public class Runner implements Runnable {
         new HttpServerOptions()
             .setPort(config.getHttpListenPort())
             .setHost(config.getHttpListenHost())
-            .setTcpKeepAlive(false)
             .setIdleTimeout(config.getIdleConnectionTimeoutSeconds())
             .setIdleTimeoutUnit(TimeUnit.SECONDS)
             .setReuseAddress(true)

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -17,7 +17,6 @@ import static tech.pegasys.eth2signer.core.service.http.handlers.ContentTypes.JS
 import static tech.pegasys.eth2signer.core.signing.KeyType.BLS;
 import static tech.pegasys.eth2signer.core.signing.KeyType.SECP256K1;
 
-import java.util.concurrent.TimeUnit;
 import tech.pegasys.eth2signer.core.config.ClientAuthConstraints;
 import tech.pegasys.eth2signer.core.config.Config;
 import tech.pegasys.eth2signer.core.config.TlsOptions;
@@ -51,6 +50,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
 import com.google.common.base.Charsets;
@@ -280,7 +280,7 @@ public class Runner implements Runnable {
             .setPort(config.getHttpListenPort())
             .setHost(config.getHttpListenHost())
             .setTcpKeepAlive(false)
-            .setIdleTimeout(5)
+            .setIdleTimeout(config.getIdleConnectionTimeoutSeconds())
             .setIdleTimeoutUnit(TimeUnit.SECONDS)
             .setReuseAddress(true)
             .setReusePort(true);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -17,6 +17,7 @@ import static tech.pegasys.eth2signer.core.service.http.handlers.ContentTypes.JS
 import static tech.pegasys.eth2signer.core.signing.KeyType.BLS;
 import static tech.pegasys.eth2signer.core.signing.KeyType.SECP256K1;
 
+import java.util.concurrent.TimeUnit;
 import tech.pegasys.eth2signer.core.config.ClientAuthConstraints;
 import tech.pegasys.eth2signer.core.config.Config;
 import tech.pegasys.eth2signer.core.config.TlsOptions;
@@ -278,6 +279,9 @@ public class Runner implements Runnable {
         new HttpServerOptions()
             .setPort(config.getHttpListenPort())
             .setHost(config.getHttpListenHost())
+            .setTcpKeepAlive(false)
+            .setIdleTimeout(5)
+            .setIdleTimeoutUnit(TimeUnit.SECONDS)
             .setReuseAddress(true)
             .setReusePort(true);
     final HttpServerOptions tlsServerOptions = applyConfigTlsSettingsTo(serverOptions);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/config/Config.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/config/Config.java
@@ -47,4 +47,6 @@ public interface Config {
   Long getKeyCacheLimit();
 
   Optional<TlsOptions> getTlsOptions();
+
+  int getIdleConnectionTimeoutSeconds();
 }


### PR DESCRIPTION
It was identified that Teku/Eth2Signer could fail due to neither side removing idle connections, with Teku creating a new connection for every signing operation.

This change means that Eth2Signer will  automatically close idle connections after 5 seconds.