### PR TITLE
Fix base32 decode hack for lowercase values

### DIFF
--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/FilecoinAddressTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/FilecoinAddressTest.java
@@ -56,7 +56,7 @@ class FilecoinAddressTest {
 
   @Test
   void addressWithInvalidChecksumThrowsError() {
-    assertThatThrownBy(() -> FilecoinAddress.decode("f17uoq6tp427uzv7fztkbsnn64iwotfrristwprz"))
+    assertThatThrownBy(() -> FilecoinAddress.decode("f17uoq6tp427uzv7fztkbsnn64iwotfrristwpr"))
         .isInstanceOf(InvalidAddressChecksumException.class)
         .hasMessage("Filecoin address checksum doesn't match");
   }


### PR DESCRIPTION
This removes hack we had for handling lowercase base32 decoding in the Filecoin address by using guava base32 encoder which supports lowercase characters.

Fix #170 