### PR TITLE
FC Verify without loaded keys

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/filecoin/FcBlsVerifyAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/filecoin/FcBlsVerifyAcceptanceTest.java
@@ -21,17 +21,14 @@ import tech.pegasys.eth2signer.core.service.jsonrpc.FcJsonRpc;
 import tech.pegasys.eth2signer.core.service.jsonrpc.FilecoinSignature;
 import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
 import tech.pegasys.eth2signer.core.signing.FcBlsArtifactSigner;
-import tech.pegasys.eth2signer.core.signing.KeyType;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinAddress;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinNetwork;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
-import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSecretKey;
 
-import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
 
@@ -44,7 +41,6 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class FcBlsVerifyAcceptanceTest extends AcceptanceTestBase {
   private static final String dataString =
@@ -52,8 +48,6 @@ public class FcBlsVerifyAcceptanceTest extends AcceptanceTestBase {
   private static final String PRIVATE_KEY =
       "5abc1334d98d1432150df310f9d2fd51780a2b8a7489891f5d4ab9e77e6fb169";
 
-  protected @TempDir Path testDirectory;
-  private static final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
   private static final BLSSecretKey key = BLSSecretKey.fromBytes(Bytes.fromHexString(PRIVATE_KEY));
   private static final BLSKeyPair keyPair = new BLSKeyPair(key);
   private static final BLSPublicKey publicKey = keyPair.getPublicKey();
@@ -67,13 +61,7 @@ public class FcBlsVerifyAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   void receiveTrueResponseWhenSubmitValidVerifyRequestToFilecoinEndpoint() {
-    final String configFilename = publicKey.toString().substring(2);
-    final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
-    metadataFileHelpers.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY, KeyType.BLS);
-
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+    startSigner(new SignerConfigurationBuilder().build());
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
     final ObjectMapper mapper = new ObjectMapper();

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/filecoin/FcSecpVerifyAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/filecoin/FcSecpVerifyAcceptanceTest.java
@@ -19,16 +19,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 import tech.pegasys.eth2signer.core.service.jsonrpc.FcJsonRpc;
 import tech.pegasys.eth2signer.core.service.jsonrpc.FilecoinSignature;
-import tech.pegasys.eth2signer.core.signing.KeyType;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinAddress;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinNetwork;
 import tech.pegasys.eth2signer.dsl.signer.SignerConfigurationBuilder;
-import tech.pegasys.eth2signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.eth2signer.tests.AcceptanceTestBase;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
 
@@ -37,18 +32,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.arteam.simplejsonrpc.core.domain.Request;
-import com.google.common.io.Resources;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class FcSecpVerifyAcceptanceTest extends AcceptanceTestBase {
-  protected @TempDir Path testDirectory;
-
-  private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
-
   // Public Key of Keystore stored in resource "secp256k1/wallet.json"
   public static final String PUBLIC_KEY_HEX_STRING =
       "09b02f8a5fddd222ade4ea4528faefc399623af3f736be3c44f03e2df22fb792f3931a4d9573d333ca74343305762a753388c3422a86d98b713fc91c1ea04842";
@@ -59,19 +48,8 @@ public class FcSecpVerifyAcceptanceTest extends AcceptanceTestBase {
       FilecoinAddress.secpAddress(Bytes.fromHexString("04" + PUBLIC_KEY_HEX_STRING));
 
   @Test
-  void receiveTrueResponseWhenSubmitValidVerifyRequestToFilecoinEndpoint()
-      throws URISyntaxException {
-    final String keyPath =
-        new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
-
-    final Path keyConfigFile = testDirectory.resolve("arbitrary_secp.yaml");
-
-    metadataFileHelpers.createKeyStoreYamlFileAt(
-        keyConfigFile, Path.of(keyPath), "pass", KeyType.SECP256K1);
-
-    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder.withKeyStoreDirectory(testDirectory);
-    startSigner(builder.build());
+  void receiveTrueResponseWhenSubmitValidVerifyRequestToFilecoinEndpoint() {
+    startSigner(new SignerConfigurationBuilder().build());
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
     final ObjectMapper mapper = new ObjectMapper();

--- a/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/Runner.java
@@ -37,9 +37,7 @@ import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
 import tech.pegasys.eth2signer.core.signing.FileCoinArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.signing.LoadedSigners;
 import tech.pegasys.eth2signer.core.signing.SecpArtifactSignature;
-import tech.pegasys.eth2signer.core.util.ByteUtils;
 import tech.pegasys.eth2signer.core.util.FileUtil;
-import tech.pegasys.signers.secp256k1.api.Signature;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -76,8 +74,6 @@ import io.vertx.ext.web.impl.BlockingHandlerDecorator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.net.tls.VertxTrustOptions;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
@@ -211,13 +207,7 @@ public class Runner implements Runnable {
   }
 
   private String formatSecpSignature(final SecpArtifactSignature signature) {
-    final Signature signatureData = signature.getSignatureData();
-    final Bytes outputSignature =
-        Bytes.concatenate(
-            Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getR()))),
-            Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getS()))),
-            Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getV())));
-    return outputSignature.toHexString();
+    return SecpArtifactSignature.toBytes(signature).toHexString();
   }
 
   private OpenAPI3RouterFactory getOpenAPI3RouterFactory(final Vertx vertx)

--- a/core/src/main/java/tech/pegasys/eth2signer/core/service/jsonrpc/FcJsonRpc.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/service/jsonrpc/FcJsonRpc.java
@@ -18,7 +18,6 @@ import tech.pegasys.eth2signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
 import tech.pegasys.eth2signer.core.signing.SecpArtifactSignature;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinAddress;
-import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinProtocol;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinVerify;
 import tech.pegasys.eth2signer.core.signing.filecoin.exceptions.FilecoinSignerNotFoundException;
 import tech.pegasys.eth2signer.core.util.ByteUtils;
@@ -112,16 +111,18 @@ public class FcJsonRpc {
       @JsonRpcParam("signature") final FilecoinSignature filecoinSignature) {
     final FilecoinAddress address = FilecoinAddress.fromString(filecoinAddress);
     final Bytes signature = Bytes.fromBase64String(filecoinSignature.getData());
-    if (address.getProtocol() == FilecoinProtocol.SECP256K1) {
-      return FilecoinVerify.verify(
-          address, Bytes.fromBase64String(dataToVerify), createSecpArtifactSignature(signature));
-    } else if (address.getProtocol() == FilecoinProtocol.BLS) {
-      return FilecoinVerify.verify(
-          address,
-          Bytes.fromBase64String(dataToVerify),
-          new BlsArtifactSignature(BLSSignature.fromBytes(signature)));
-    } else {
-      throw new IllegalArgumentException("Invalid Signature type");
+
+    switch (address.getProtocol()) {
+      case SECP256K1:
+        return FilecoinVerify.verify(
+            address, Bytes.fromBase64String(dataToVerify), createSecpArtifactSignature(signature));
+      case BLS:
+        return FilecoinVerify.verify(
+            address,
+            Bytes.fromBase64String(dataToVerify),
+            new BlsArtifactSignature(BLSSignature.fromBytes(signature)));
+      default:
+        throw new IllegalArgumentException("Invalid address protocol type");
     }
   }
 

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/ArtifactSigner.java
@@ -19,6 +19,4 @@ public interface ArtifactSigner {
   String getIdentifier();
 
   ArtifactSignature sign(final Bytes message);
-
-  boolean verify(final Bytes message, final ArtifactSignature signature);
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSigner.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.eth2signer.core.service.operations.IdentifierUtils.normaliseIdentifier;
 
 import tech.pegasys.teku.bls.BLS;
@@ -36,12 +35,5 @@ public class BlsArtifactSigner implements ArtifactSigner {
   @Override
   public BlsArtifactSignature sign(final Bytes data) {
     return new BlsArtifactSignature(BLS.sign(keyPair.getSecretKey(), data));
-  }
-
-  @Override
-  public boolean verify(final Bytes data, final ArtifactSignature signature) {
-    checkArgument(signature instanceof BlsArtifactSignature);
-    final BlsArtifactSignature blsArtifactSignature = (BlsArtifactSignature) signature;
-    return BLS.verify(keyPair.getPublicKey(), data, blsArtifactSignature.getSignatureData());
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/EthSecpArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/EthSecpArtifactSigner.java
@@ -12,26 +12,14 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.eth2signer.core.service.operations.IdentifierUtils.normaliseIdentifier;
 
 import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
-import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
 
-import java.math.BigInteger;
-import java.security.SignatureException;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
-import org.web3j.crypto.Hash;
-import org.web3j.crypto.Sign;
-import org.web3j.crypto.Sign.SignatureData;
-import org.web3j.utils.Numeric;
 
 public class EthSecpArtifactSigner implements ArtifactSigner {
-  private static final Logger LOG = LogManager.getLogger();
   private final Signer signer;
 
   public EthSecpArtifactSigner(final Signer signer) {
@@ -46,29 +34,5 @@ public class EthSecpArtifactSigner implements ArtifactSigner {
   @Override
   public SecpArtifactSignature sign(final Bytes message) {
     return new SecpArtifactSignature(signer.sign(message.toArray()));
-  }
-
-  @Override
-  public boolean verify(final Bytes message, final ArtifactSignature artifactSignature) {
-    checkArgument(artifactSignature instanceof SecpArtifactSignature);
-    final SecpArtifactSignature secpArtifactSignature = (SecpArtifactSignature) artifactSignature;
-    final Signature signature = secpArtifactSignature.getSignatureData();
-    final SignatureData signatureData =
-        new SignatureData(
-            Numeric.toBytesPadded(signature.getV(), 1),
-            Numeric.toBytesPadded(signature.getR(), 32),
-            Numeric.toBytesPadded(signature.getS(), 32));
-
-    final byte[] digest = Hash.sha3(message.toArrayUnsafe());
-
-    try {
-      final BigInteger signaturePublicKey = Sign.signedMessageHashToKey(digest, signatureData);
-      final BigInteger expectedPublicKey =
-          Numeric.toBigInt(EthPublicKeyUtils.toByteArray(signer.getPublicKey()));
-      return signaturePublicKey.equals(expectedPublicKey);
-    } catch (final SignatureException e) {
-      LOG.error("Unable to recover public key from signature", e);
-      return false;
-    }
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSigner.java
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.tuweni.bytes.Bytes;
 
 public class FcBlsArtifactSigner implements ArtifactSigner {
-  private static final Bytes DST =
+  public static final Bytes FC_DST =
       Bytes.wrap("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_".getBytes(StandardCharsets.US_ASCII));
 
   private final BLSKeyPair keyPair;
@@ -44,7 +44,7 @@ public class FcBlsArtifactSigner implements ArtifactSigner {
 
   @Override
   public BlsArtifactSignature sign(final Bytes message) {
-    final G2Point hashInGroup2 = new G2Point(hashToG2(message, DST));
+    final G2Point hashInGroup2 = new G2Point(hashToG2(message, FC_DST));
     final G2Point g2Point = keyPair.getSecretKey().getSecretKey().sign(hashInGroup2);
     final BLSSignature blsSignature = new BLSSignature(new Signature(g2Point));
     return new BlsArtifactSignature(blsSignature);

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSigner.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.bls.hashToG2.HashToCurve.hashToG2;
 
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinAddress;
@@ -49,14 +48,5 @@ public class FcBlsArtifactSigner implements ArtifactSigner {
     final G2Point g2Point = keyPair.getSecretKey().getSecretKey().sign(hashInGroup2);
     final BLSSignature blsSignature = new BLSSignature(new Signature(g2Point));
     return new BlsArtifactSignature(blsSignature);
-  }
-
-  @Override
-  public boolean verify(final Bytes message, final ArtifactSignature artifactSignature) {
-    checkArgument(artifactSignature instanceof BlsArtifactSignature);
-    final BlsArtifactSignature blsArtifactSignature = (BlsArtifactSignature) artifactSignature;
-    final Signature signature = blsArtifactSignature.getSignatureData().getSignature();
-    final G2Point hashInGroup2 = new G2Point(hashToG2(message, DST));
-    return signature.verify(keyPair.getPublicKey().getPublicKey(), hashInGroup2);
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcSecpArtifactSigner.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/FcSecpArtifactSigner.java
@@ -12,29 +12,20 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinAddress;
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinNetwork;
 import tech.pegasys.eth2signer.core.util.Blake2b;
-import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPublicKey;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.web3j.crypto.ECDSASignature;
-import org.web3j.crypto.Sign;
-import org.web3j.utils.Numeric;
 
 public class FcSecpArtifactSigner implements ArtifactSigner {
-  private static final Logger LOG = LogManager.getLogger();
   private static final int ETHEREUM_V_OFFSET = 27;
   private final Signer signer;
   private final FilecoinNetwork filecoinNetwork;
@@ -66,29 +57,5 @@ public class FcSecpArtifactSigner implements ArtifactSigner {
             ethSignature.getS());
 
     return new SecpArtifactSignature(fcSignature);
-  }
-
-  @Override
-  public boolean verify(final Bytes message, final ArtifactSignature signature) {
-    checkArgument(signature instanceof SecpArtifactSignature);
-    final SecpArtifactSignature secpArtifactSignature = (SecpArtifactSignature) signature;
-    final Signature signatureData = secpArtifactSignature.getSignatureData();
-
-    final ECDSASignature initialSignature =
-        new ECDSASignature(signatureData.getR(), signatureData.getS());
-    final ECDSASignature canonicalSignature = initialSignature.toCanonicalised();
-
-    final int recId = signatureData.getV().intValue();
-    final byte[] digest = Blake2b.sum256(message).toArrayUnsafe();
-    final BigInteger signaturePublicKey =
-        Sign.recoverFromSignature(recId, canonicalSignature, digest);
-    if (signaturePublicKey == null) {
-      LOG.error("Unable to recover public key from signature");
-      return false;
-    } else {
-      final BigInteger expectedPublicKey =
-          Numeric.toBigInt(EthPublicKeyUtils.toByteArray(signer.getPublicKey()));
-      return signaturePublicKey.equals(expectedPublicKey);
-    }
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/SecpArtifactSignature.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/SecpArtifactSignature.java
@@ -12,7 +12,12 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
+import tech.pegasys.eth2signer.core.util.ByteUtils;
 import tech.pegasys.signers.secp256k1.api.Signature;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.web3j.utils.Numeric;
 
 public class SecpArtifactSignature implements ArtifactSignature {
   private final Signature signature;
@@ -28,5 +33,24 @@ public class SecpArtifactSignature implements ArtifactSignature {
 
   public Signature getSignatureData() {
     return signature;
+  }
+
+  public static SecpArtifactSignature fromBytes(final Bytes signature) {
+    final Bytes r = signature.slice(0, 32);
+    final Bytes s = signature.slice(32, 32);
+    final Bytes v = signature.slice(64);
+    return new SecpArtifactSignature(
+        new Signature(
+            Numeric.toBigInt(v.toArrayUnsafe()),
+            Numeric.toBigInt(r.toArrayUnsafe()),
+            Numeric.toBigInt(s.toArrayUnsafe())));
+  }
+
+  public static Bytes toBytes(final SecpArtifactSignature signature) {
+    final Signature signatureData = signature.getSignatureData();
+    return Bytes.concatenate(
+        Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getR()))),
+        Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getS()))),
+        Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getV())));
   }
 }

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerify.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerify.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.signing.filecoin;
+
+import static tech.pegasys.teku.bls.hashToG2.HashToCurve.hashToG2;
+
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
+import tech.pegasys.eth2signer.core.signing.SecpArtifactSignature;
+import tech.pegasys.eth2signer.core.util.Blake2b;
+import tech.pegasys.teku.bls.mikuli.G2Point;
+import tech.pegasys.teku.bls.mikuli.PublicKey;
+import tech.pegasys.teku.bls.mikuli.Signature;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.web3j.crypto.ECDSASignature;
+import org.web3j.crypto.Sign;
+import org.web3j.utils.Numeric;
+
+public class FilecoinVerify {
+  private static final Logger LOG = LogManager.getLogger();
+  private static final Bytes DST =
+      Bytes.wrap("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_".getBytes(StandardCharsets.US_ASCII));
+
+  public static boolean verify(
+      final FilecoinAddress address,
+      final Bytes message,
+      final BlsArtifactSignature artifactSignature) {
+    final PublicKey blsPublicKey = PublicKey.fromBytesCompressed(address.getPayload());
+    final Signature signature = artifactSignature.getSignatureData().getSignature();
+    final G2Point hashInGroup2 = new G2Point(hashToG2(message, DST));
+    return signature.verify(blsPublicKey, hashInGroup2);
+  }
+
+  public static boolean verify(
+      final FilecoinAddress address,
+      final Bytes message,
+      final SecpArtifactSignature artifactSignature) {
+    final tech.pegasys.signers.secp256k1.api.Signature signatureData =
+        artifactSignature.getSignatureData();
+
+    final ECDSASignature initialSignature =
+        new ECDSASignature(signatureData.getR(), signatureData.getS());
+    final ECDSASignature canonicalSignature = initialSignature.toCanonicalised();
+
+    final int recId = signatureData.getV().intValue();
+    final byte[] digest = Blake2b.sum256(message).toArrayUnsafe();
+    final BigInteger signaturePublicKey =
+        Sign.recoverFromSignature(recId, canonicalSignature, digest);
+    if (signaturePublicKey == null) {
+      LOG.error("Unable to recover public key from signature");
+      return false;
+    } else {
+      final Bytes publicKeyBytes =
+          Bytes.concatenate(
+              Bytes.of(0x4), Bytes.wrap(Numeric.toBytesPadded(signaturePublicKey, 64)));
+      final FilecoinAddress filecoinAddress = FilecoinAddress.secpAddress(publicKeyBytes);
+      return address.getPayload().equals(filecoinAddress.getPayload());
+    }
+  }
+}

--- a/core/src/main/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerify.java
+++ b/core/src/main/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerify.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.eth2signer.core.signing.filecoin;
 
+import static tech.pegasys.eth2signer.core.signing.FcBlsArtifactSigner.FC_DST;
 import static tech.pegasys.teku.bls.hashToG2.HashToCurve.hashToG2;
 
 import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
@@ -22,7 +23,6 @@ import tech.pegasys.teku.bls.mikuli.PublicKey;
 import tech.pegasys.teku.bls.mikuli.Signature;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,8 +33,6 @@ import org.web3j.utils.Numeric;
 
 public class FilecoinVerify {
   private static final Logger LOG = LogManager.getLogger();
-  private static final Bytes DST =
-      Bytes.wrap("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_".getBytes(StandardCharsets.US_ASCII));
 
   public static boolean verify(
       final FilecoinAddress address,
@@ -42,7 +40,7 @@ public class FilecoinVerify {
       final BlsArtifactSignature artifactSignature) {
     final PublicKey blsPublicKey = PublicKey.fromBytesCompressed(address.getPayload());
     final Signature signature = artifactSignature.getSignatureData().getSignature();
-    final G2Point hashInGroup2 = new G2Point(hashToG2(message, DST));
+    final G2Point hashInGroup2 = new G2Point(hashToG2(message, FC_DST));
     return signature.verify(blsPublicKey, hashInGroup2);
   }
 

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignerTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/BlsArtifactSignerTest.java
@@ -44,18 +44,4 @@ class BlsArtifactSignerTest {
 
     assertThat(signature.getSignatureData().toString()).isEqualTo(expectedSignature.toString());
   }
-
-  @Test
-  void verifiesSignatureWasSignedWithKey() {
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-
-    final BlsArtifactSigner blsArtifactSigner = new BlsArtifactSigner(BLSKeyPair.random(4));
-    final BlsArtifactSignature artifactSignature = blsArtifactSigner.sign(message);
-    assertThat(blsArtifactSigner.verify(message, artifactSignature)).isTrue();
-
-    final BLSKeyPair otherKeyPair = BLSKeyPair.random(5);
-    final BlsArtifactSigner otherBlsArtifactSigner = new BlsArtifactSigner(otherKeyPair);
-    final BlsArtifactSignature otherArtifactSignature = otherBlsArtifactSigner.sign(message);
-    assertThat(blsArtifactSigner.verify(message, otherArtifactSignature)).isFalse();
-  }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/EthSecpArtifactSignerTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/EthSecpArtifactSignerTest.java
@@ -59,18 +59,4 @@ class EthSecpArtifactSignerTest {
     assertThat(signatureData.getS()).isEqualTo(Numeric.toBigInt(expectedSignature.getS()));
     assertThat(signatureData.getV()).isEqualTo(Numeric.toBigInt(expectedSignature.getV()));
   }
-
-  @Test
-  void verifiesSignatureWasSignedWithKey() {
-    final ECKeyPair ecKeyPair =
-        new ECKeyPair(Numeric.toBigInt(PRIVATE_KEY), Numeric.toBigInt(PUBLIC_KEY));
-    final Credentials credentials = Credentials.create(ecKeyPair);
-    final EthSecpArtifactSigner ethSecpArtifactSigner =
-        new EthSecpArtifactSigner(new CredentialSigner(credentials));
-
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-    final SecpArtifactSignature signature = ethSecpArtifactSigner.sign(message);
-
-    assertThat(ethSecpArtifactSigner.verify(message, signature)).isTrue();
-  }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSignerTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/FcBlsArtifactSignerTest.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinNetwork;
@@ -58,19 +57,5 @@ class FcBlsArtifactSignerTest {
     assertThat(signature).isInstanceOf(BlsArtifactSignature.class);
     assertThat(signature.getSignatureData().toBytes().toBase64String())
         .isEqualTo(expectedSignature);
-  }
-
-  @Test
-  void verifiesSignatureWasSignedWithKey() {
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-
-    final BlsArtifactSignature artifactSignature = fcBlsArtifactSigner.sign(message);
-    assertThat(fcBlsArtifactSigner.verify(message, artifactSignature)).isTrue();
-
-    final BLSKeyPair otherKeyPair = BLSKeyPair.random(5);
-    final FcBlsArtifactSigner otherBlsArtifactSigner =
-        new FcBlsArtifactSigner(otherKeyPair, FilecoinNetwork.TESTNET);
-    final BlsArtifactSignature otherArtifactSignature = otherBlsArtifactSigner.sign(message);
-    assertThat(fcBlsArtifactSigner.verify(message, otherArtifactSignature)).isFalse();
   }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/FcSecpArtifactSignerTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/FcSecpArtifactSignerTest.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.eth2signer.core.signing;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.eth2signer.core.signing.filecoin.FilecoinNetwork;
@@ -65,21 +64,5 @@ class FcSecpArtifactSignerTest {
             Bytes32.leftPad(Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getS()))),
             Bytes.wrap(ByteUtils.bigIntegerToBytes(signatureData.getV())));
     assertThat(signatureValue.toBase64String()).isEqualTo(expectedSignature);
-  }
-
-  @Test
-  void verifiesSignatureWasSignedWithKey() {
-    final Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
-
-    final SecpArtifactSignature artifactSignature = fcSecpArtifactSigner.sign(message);
-    assertThat(fcSecpArtifactSigner.verify(message, artifactSignature)).isTrue();
-
-    final Credentials otherCredentials =
-        Credentials.create("8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
-    final FcSecpArtifactSigner otherFcSecpArtifactSigner =
-        new FcSecpArtifactSigner(
-            new CredentialSigner(otherCredentials, false), FilecoinNetwork.TESTNET);
-    final SecpArtifactSignature otherArtifactSignature = otherFcSecpArtifactSigner.sign(message);
-    assertThat(fcSecpArtifactSigner.verify(message, otherArtifactSignature)).isFalse();
   }
 }

--- a/core/src/test/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerifyTest.java
+++ b/core/src/test/java/tech/pegasys/eth2signer/core/signing/filecoin/FilecoinVerifyTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.eth2signer.core.signing.filecoin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.eth2signer.core.signing.BlsArtifactSignature;
+import tech.pegasys.eth2signer.core.signing.SecpArtifactSignature;
+import tech.pegasys.signers.secp256k1.api.Signature;
+import tech.pegasys.teku.bls.BLSSignature;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import org.web3j.utils.Numeric;
+
+class FilecoinVerifyTest {
+  private static final String DATA = "NDI=";
+  private static final String BLS_SIGNATURE =
+      "p/LeJS8KPzuOco2qpqjhvJxFrA5qj++LpeVoActWkDRQTLhuGsnwAvY1kluQ6PntAqISjvR/RU0kzgkR38F8Hm5NuNPsu9/BEiU+IQheNeD7OoG8THq4OuZMbISg7uR/";
+  private static final String SECP_SIGNATURE =
+      "4ZDlbvzXtjFnGAnkmnAXImN7KmE+OdW3KbCn+UIHJwY3hEbodjS0VIVBiPUxRWbhJOMao3Sx7GWb4myEsYouJgA=";
+
+  @Test
+  void verifiesBlsSignatureWasSignedWithKey() {
+    final Bytes message = Bytes.fromBase64String(DATA);
+
+    final BlsArtifactSignature artifactSignature =
+        new BlsArtifactSignature(BLSSignature.fromBytes(Bytes.fromBase64String(BLS_SIGNATURE)));
+    final FilecoinAddress filecoinAddress =
+        FilecoinAddress.fromString(
+            "t3sjhgtrk5fdio52k5lzanh7yy4mj4rqbiowd6odddzprrxejgbjbl2irr3gmpbf7epigf45oy7asljj3v3lva");
+    assertThat(FilecoinVerify.verify(filecoinAddress, message, artifactSignature)).isTrue();
+  }
+
+  @Test
+  void verifiesSecpSignatureWasSignedWithKey() {
+    final Bytes message = Bytes.fromBase64String(DATA);
+
+    final SecpArtifactSignature artifactSignature =
+        createSecpArtifactSignature(Bytes.fromBase64String(SECP_SIGNATURE));
+    final FilecoinAddress filecoinAddress =
+        FilecoinAddress.fromString("t1656rklyebnscuzs5dee3zwh2xknlqsy7r2ypxei");
+    assertThat(FilecoinVerify.verify(filecoinAddress, message, artifactSignature)).isTrue();
+  }
+
+  private SecpArtifactSignature createSecpArtifactSignature(final Bytes signature) {
+    final Bytes r = signature.slice(0, 32);
+    final Bytes s = signature.slice(32, 32);
+    final Bytes v = signature.slice(64);
+    return new SecpArtifactSignature(
+        new Signature(
+            Numeric.toBigInt(v.toArrayUnsafe()),
+            Numeric.toBigInt(r.toArrayUnsafe()),
+            Numeric.toBigInt(s.toArrayUnsafe())));
+  }
+}


### PR DESCRIPTION
Change FC verify RPC so that keys don't need to be loaded for FC verify to work.