### PR TITLE
Catch more info for a failed sign message comparative test

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
@@ -116,8 +116,8 @@ public class FilecoinJsonRequests {
     post.setEntity(new StringEntity(request, Charsets.UTF_8));
     post.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
     final String authToken = System.getenv("ETH2SIGNER_BEARER_TOKEN");
-    if(authToken != null) {
-      post.setHeader("Authorization","Bearer " + authToken);
+    if (authToken != null) {
+      post.setHeader("Authorization", "Bearer " + authToken);
     }
     try (final CloseableHttpClient httpClient = HttpClients.createDefault();
         final CloseableHttpResponse httpResponse = httpClient.execute(post)) {

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
@@ -115,6 +115,10 @@ public class FilecoinJsonRequests {
     final HttpPost post = new HttpPost(url);
     post.setEntity(new StringEntity(request, Charsets.UTF_8));
     post.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+    final String authToken = System.getenv("ETH2SIGNER_BEARER_TOKEN");
+    if(authToken != null) {
+      post.setHeader("Authorization","Bearer " + authToken);
+    }
     try (final CloseableHttpClient httpClient = HttpClients.createDefault();
         final CloseableHttpResponse httpResponse = httpClient.execute(post)) {
       return EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8);

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/dsl/lotus/FilecoinJsonRequests.java
@@ -18,6 +18,7 @@ import tech.pegasys.eth2signer.core.service.jsonrpc.FilecoinSignedMessage;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import com.github.arteam.simplejsonrpc.client.JsonRpcClient;
 import com.google.common.net.MediaType;
@@ -34,6 +35,10 @@ import org.apache.tuweni.bytes.Bytes;
 public class FilecoinJsonRequests {
   public static final int BLS_SIGTYPE = 1;
   public static final int SECP_SIGTYPE = 2;
+
+  // This is required to be set if operating against a full Lotus node (as opposed to dev-lotus).
+  private static final Optional<String> authToken =
+      Optional.ofNullable(System.getenv("ETH2SIGNER_BEARER_TOKEN"));
 
   public static String walletNew(final JsonRpcClient jsonRpcClient, int sigType) {
     return jsonRpcClient
@@ -115,10 +120,7 @@ public class FilecoinJsonRequests {
     final HttpPost post = new HttpPost(url);
     post.setEntity(new StringEntity(request, Charsets.UTF_8));
     post.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
-    final String authToken = System.getenv("ETH2SIGNER_BEARER_TOKEN");
-    if (authToken != null) {
-      post.setHeader("Authorization", "Bearer " + authToken);
-    }
+    authToken.ifPresent(token -> post.setHeader("Authorization", "Bearer " + token));
     try (final CloseableHttpClient httpClient = HttpClients.createDefault();
         final CloseableHttpResponse httpResponse = httpClient.execute(post)) {
       return EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8);

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/comparison/CompareSignMessageAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/comparison/CompareSignMessageAcceptanceTest.java
@@ -115,7 +115,8 @@ public class CompareSignMessageAcceptanceTest extends CompareApisAcceptanceTestB
                       "Signature Comparison failed from msg = "
                           + jsonRequest
                           + ". With Priv key = ("
-                          + addressMap.get(address).getType().toString() + ") "
+                          + addressMap.get(address).getType().toString()
+                          + ") "
                           + addressMap.get(address).getPrivateKeyHex())
                   .isEqualToComparingFieldByField(signerFcSig.getSignature());
             });

--- a/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/comparison/CompareSignMessageAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/eth2signer/tests/comparison/CompareSignMessageAcceptanceTest.java
@@ -114,8 +114,9 @@ public class CompareSignMessageAcceptanceTest extends CompareApisAcceptanceTestB
                   .overridingErrorMessage(
                       "Signature Comparison failed from msg = "
                           + jsonRequest
-                          + ". With addr = "
-                          + address)
+                          + ". With Priv key = ("
+                          + addressMap.get(address).getType().toString() + ") "
+                          + addressMap.get(address).getPrivateKeyHex())
                   .isEqualToComparingFieldByField(signerFcSig.getSignature());
             });
   }


### PR DESCRIPTION
Lotus Auth token can now be set via env var
such that comparative tests can be run against
a live, real, Lotus instance (rather than a devnet variant).